### PR TITLE
fix(popup): add read stories visibility preference

### DIFF
--- a/src/components/story/hide-read-stories.test.ts
+++ b/src/components/story/hide-read-stories.test.ts
@@ -1,22 +1,47 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { browser } from '#imports';
+import { browser, type ContentScriptContext } from '#imports';
+import { createClientServices } from '@/services/manager.ts';
 import { ReadStoriesService } from '@/services/read-stories-service.ts';
 import { stripFixtureElements } from '@/test/fixture-html.ts';
 import lStorage from '@/utils/local-storage.ts';
-import { getShowHiddenStoriesOptionPreference } from '@/utils/preferences.ts';
 import {
+	getReadStoriesVisibilityPreference,
+	getShowHiddenStoriesOptionPreference,
+	READ_STORIES_VISIBILITY,
+	type ReadStoriesVisibilityPreference,
+} from '@/utils/preferences.ts';
+import { registerPreferencesUpdateHandler } from '@/utils/preferences-live.ts';
+import {
+	applyReadStoriesVisibility,
 	createCheckbox,
+	hideReadStories,
+	hideReadStoriesOnce,
 	hideStories,
 	type StorageState,
 	setupCheckbox,
 	showStories,
 } from './hide-read-stories.ts';
 import { HNStory } from './hn-story.ts';
+import { StoryData } from './story-data.ts';
+
+vi.mock('@/services/manager.ts', () => ({
+	createClientServices: vi.fn(),
+}));
 
 vi.mock('@/utils/preferences.ts', () => ({
+	getReadStoriesVisibilityPreference: vi.fn(async () => 0),
 	getShowHiddenStoriesOptionPreference: vi.fn(async () => true),
+	READ_STORIES_VISIBILITY: {
+		HIDE: 0,
+		STRIKETHROUGH: 1,
+		DIM: 2,
+	},
+}));
+
+vi.mock('@/utils/preferences-live.ts', () => ({
+	registerPreferencesUpdateHandler: vi.fn(),
 }));
 
 const STORY_LIST_HTML_REGEX = /class="itemlist"/;
@@ -37,11 +62,61 @@ const emptyPageHtml = readFileSync(
 
 describe('hide_read_stories', () => {
 	let service: ReadStoriesService;
+	let mockGetVisitsForHideReadStories: ReturnType<typeof vi.fn>;
+
+	const createStoryData = (): StoryData => {
+		const wrapper = document.createElement('div');
+		const table = document.createElement('table');
+		const tbody = document.createElement('tbody');
+		const bigboxRow = document.createElement('tr');
+		const bigboxCell = document.createElement('td');
+		const bigbox = document.createElement('div');
+		bigbox.id = 'bigbox';
+		bigboxCell.append(bigbox);
+		bigboxRow.append(bigboxCell);
+		tbody.append(bigboxRow);
+
+		const createStoryRows = (id: string, title: string): HTMLElement => {
+			const storyRow = document.createElement('tr');
+			storyRow.className = 'athing';
+			storyRow.id = id;
+			storyRow.innerHTML = `<td><span class="titleline"><a href="https://example.com/${id}">${title}</a></span></td>`;
+
+			const subtextRow = document.createElement('tr');
+			subtextRow.innerHTML = '<td class="subtext"></td>';
+
+			const spacerRow = document.createElement('tr');
+			spacerRow.innerHTML = '<td></td>';
+
+			tbody.append(storyRow, subtextRow, spacerRow);
+			return storyRow;
+		};
+
+		const firstStoryRow = createStoryRows('story-1', 'Story one');
+		createStoryRows('story-2', 'Story two');
+
+		table.append(tbody);
+		wrapper.append(table);
+		document.body.append(wrapper);
+
+		return new StoryData(bigbox, [firstStoryRow]);
+	};
+
 	beforeEach(() => {
 		document.body.innerHTML = '';
 		lStorage.clear();
 		vi.clearAllMocks();
+		mockGetVisitsForHideReadStories = vi.fn();
+		vi.mocked(createClientServices).mockReturnValue({
+			getReadStoriesService: () => ({
+				getVisits: mockGetVisitsForHideReadStories,
+			}),
+		} as unknown as ReturnType<typeof createClientServices>);
+		vi.mocked(getReadStoriesVisibilityPreference).mockResolvedValue(
+			READ_STORIES_VISIBILITY.HIDE
+		);
 		vi.mocked(getShowHiddenStoriesOptionPreference).mockResolvedValue(true);
+		vi.mocked(registerPreferencesUpdateHandler).mockImplementation(() => {});
 		service = new ReadStoriesService();
 	});
 
@@ -116,6 +191,36 @@ describe('hide_read_stories', () => {
 			}).not.toThrow();
 		});
 
+		it('should strikethrough the story title when configured', () => {
+			const storyRow = document.createElement('tr');
+			storyRow.id = 'strike-story';
+			storyRow.innerHTML = '<td><span class="titleline"><a href="#">Story</a></span></td>';
+			document.body.appendChild(storyRow);
+
+			const story = new HNStory(storyRow);
+			const titleLink = storyRow.querySelector<HTMLAnchorElement>('span.titleline > a');
+
+			applyReadStoriesVisibility([story], READ_STORIES_VISIBILITY.STRIKETHROUGH);
+
+			expect(titleLink?.style.textDecoration).toBe('line-through');
+			expect(storyRow.style.display).toBe('');
+		});
+
+		it('should dim the story title when configured', () => {
+			const storyRow = document.createElement('tr');
+			storyRow.id = 'dim-story';
+			storyRow.innerHTML = '<td><span class="titleline"><a href="#">Story</a></span></td>';
+			document.body.appendChild(storyRow);
+
+			const story = new HNStory(storyRow);
+			const titleLink = storyRow.querySelector<HTMLAnchorElement>('span.titleline > a');
+
+			applyReadStoriesVisibility([story], READ_STORIES_VISIBILITY.DIM);
+
+			expect(titleLink?.style.opacity).toBe('0.45');
+			expect(storyRow.style.display).toBe('');
+		});
+
 		it('should handle story without subtext or spacer rows', () => {
 			const storyRow = document.createElement('tr');
 			storyRow.id = 'lonely-story';
@@ -153,6 +258,119 @@ describe('hide_read_stories', () => {
 			expect(cell).not.toBeNull();
 			expect(cell?.style.paddingLeft).toBe('5px');
 			expect(cell?.style.paddingBottom).toBe('10px');
+		});
+	});
+
+	describe('feature interactions', () => {
+		it('keeps visited stories visible until the page checkbox is checked', async () => {
+			const storyData = createStoryData();
+			const visitedStory = storyData.hnStories[0];
+			mockGetVisitsForHideReadStories.mockResolvedValue([
+				{ id: visitedStory.id, latestVisit: {} },
+			]);
+			vi.mocked(getReadStoriesVisibilityPreference).mockResolvedValue(
+				READ_STORIES_VISIBILITY.DIM
+			);
+			const ctx = { onInvalidated: vi.fn() } as unknown as ContentScriptContext;
+
+			await hideReadStories(ctx, document, storyData);
+
+			const checkbox = document.querySelector<HTMLInputElement>('#oj-hide-read-stories');
+			const titleLink =
+				visitedStory.storyRow.querySelector<HTMLAnchorElement>('span.titleline > a');
+			expect(checkbox?.checked).toBe(false);
+			expect(titleLink?.style.opacity).toBe('');
+			expect(visitedStory.storyRow.style.display).toBe('');
+
+			if (!checkbox) {
+				throw new Error('Expected page checkbox to exist');
+			}
+
+			checkbox.checked = true;
+			checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+			await vi.waitFor(() => {
+				expect(titleLink?.style.opacity).toBe('0.45');
+			});
+			expect(await lStorage.getItem<StorageState>('oj_hide_read_stories')).toEqual({
+				checkbox: true,
+			});
+		});
+
+		it('updates checked stories when the read stories visibility preference changes', async () => {
+			let currentVisibility: ReadStoriesVisibilityPreference =
+				READ_STORIES_VISIBILITY.STRIKETHROUGH;
+			vi.mocked(getReadStoriesVisibilityPreference).mockImplementation(
+				async () => currentVisibility
+			);
+			await lStorage.setItem<StorageState>('oj_hide_read_stories', { checkbox: true });
+
+			const storyData = createStoryData();
+			const visitedStory = storyData.hnStories[0];
+			mockGetVisitsForHideReadStories.mockResolvedValue([
+				{ id: visitedStory.id, latestVisit: {} },
+			]);
+			let preferencesHandler: (() => Promise<void> | void) | undefined;
+			vi.mocked(registerPreferencesUpdateHandler).mockImplementation((_ctx, handler) => {
+				preferencesHandler = handler;
+			});
+			const ctx = { onInvalidated: vi.fn() } as unknown as ContentScriptContext;
+
+			await hideReadStories(ctx, document, storyData);
+
+			const titleLink =
+				visitedStory.storyRow.querySelector<HTMLAnchorElement>('span.titleline > a');
+			expect(titleLink?.style.textDecoration).toBe('line-through');
+
+			currentVisibility = READ_STORIES_VISIBILITY.DIM;
+			if (!preferencesHandler) {
+				throw new Error('Expected preferences update handler to be registered');
+			}
+			await preferencesHandler();
+
+			expect(titleLink?.style.textDecoration).toBe('');
+			expect(titleLink?.style.opacity).toBe('0.45');
+		});
+
+		it.each([
+			{
+				name: 'hides visited stories once when visibility is hide',
+				visibility: READ_STORIES_VISIBILITY.HIDE,
+				assertion: (story: HNStory, titleLink: HTMLAnchorElement | null) => {
+					expect(story.storyRow.style.display).toBe('none');
+					expect(titleLink?.style.textDecoration).toBe('');
+					expect(titleLink?.style.opacity).toBe('');
+				},
+			},
+			{
+				name: 'strikes through visited stories once when visibility is strikethrough',
+				visibility: READ_STORIES_VISIBILITY.STRIKETHROUGH,
+				assertion: (story: HNStory, titleLink: HTMLAnchorElement | null) => {
+					expect(story.storyRow.style.display).toBe('');
+					expect(titleLink?.style.textDecoration).toBe('line-through');
+				},
+			},
+			{
+				name: 'dims visited stories once when visibility is dim',
+				visibility: READ_STORIES_VISIBILITY.DIM,
+				assertion: (story: HNStory, titleLink: HTMLAnchorElement | null) => {
+					expect(story.storyRow.style.display).toBe('');
+					expect(titleLink?.style.opacity).toBe('0.45');
+				},
+			},
+		])('$name', async ({ visibility, assertion }) => {
+			const storyData = createStoryData();
+			const visitedStory = storyData.hnStories[0];
+			mockGetVisitsForHideReadStories.mockResolvedValue([
+				{ id: visitedStory.id, latestVisit: {} },
+			]);
+			vi.mocked(getReadStoriesVisibilityPreference).mockResolvedValue(visibility);
+
+			await hideReadStoriesOnce(storyData);
+
+			const titleLink =
+				visitedStory.storyRow.querySelector<HTMLAnchorElement>('span.titleline > a');
+			assertion(visitedStory, titleLink);
 		});
 	});
 
@@ -215,6 +433,20 @@ describe('hide_read_stories', () => {
 
 			expect(result).toBeNull();
 			expect(container.querySelector('#oj-hide-read-stories')).toBeNull();
+		});
+
+		it('should still create the checkbox when read stories visibility is hide', async () => {
+			vi.mocked(getReadStoriesVisibilityPreference).mockResolvedValueOnce(
+				READ_STORIES_VISIBILITY.HIDE
+			);
+			const container = document.createElement('div');
+			const bigbox = document.createElement('div');
+			bigbox.id = 'bigbox';
+			container.appendChild(bigbox);
+
+			const result = await setupCheckbox(bigbox, document);
+
+			expect(result).not.toBeNull();
 		});
 	});
 

--- a/src/components/story/hide-read-stories.ts
+++ b/src/components/story/hide-read-stories.ts
@@ -4,7 +4,11 @@ import type { StoryData } from '@/components/story/story-data.ts';
 import { createClientServices } from '@/services/manager.ts';
 import type { ReadStoriesService, ReadStoryLookup } from '@/services/read-stories-service.ts';
 import lStorage from '@/utils/local-storage.ts';
-import { getShowHiddenStoriesOptionPreference } from '@/utils/preferences.ts';
+import {
+	getReadStoriesVisibilityPreference,
+	getShowHiddenStoriesOptionPreference,
+	type ReadStoriesVisibilityPreference,
+} from '@/utils/preferences.ts';
 import { registerPreferencesUpdateHandler } from '@/utils/preferences-live.ts';
 
 const CHECKBOX_ID = 'oj-hide-read-stories';
@@ -40,7 +44,7 @@ const setDisplay = (readStories: HNStory[], display: string) => {
 		if (display === 'none') {
 			story.hide();
 		} else {
-			story.show();
+			story.resetReadPresentation();
 		}
 	}
 };
@@ -51,6 +55,15 @@ export const hideStories = (readStories: HNStory[]): void => {
 
 export const showStories = (readStories: HNStory[]): void => {
 	setDisplay(readStories, '');
+};
+
+export const applyReadStoriesVisibility = (
+	readStories: HNStory[],
+	visibility: ReadStoriesVisibilityPreference
+): void => {
+	for (const story of readStories) {
+		story.applyReadStoriesVisibility(visibility);
+	}
 };
 
 export interface StorageState {
@@ -104,7 +117,6 @@ const getVisitedStories = async (
 				const found = map.get(story.id);
 				if (found) {
 					found.latestVisit = story.latestVisit;
-					found.hide();
 					ret.push(found);
 				}
 			}
@@ -124,14 +136,18 @@ export const hideReadStories = async (
 	try {
 		const service = createClientServices().getReadStoriesService();
 		const updateVisits = async () => {
-			if (!checkbox) {
-				return;
-			}
 			const readStories = await getVisitedStories(service, storyData.hnStories);
 			if (!readStories) {
 				return;
 			}
-			checkbox.checked ? hideStories(readStories) : showStories(readStories);
+			const visibility = await getReadStoriesVisibilityPreference();
+			if (!checkbox) {
+				applyReadStoriesVisibility(readStories, visibility);
+				return;
+			}
+			checkbox.checked
+				? applyReadStoriesVisibility(readStories, visibility)
+				: showStories(readStories);
 		};
 		let checkbox: HTMLInputElement | null = null;
 		let handleCheckboxChange: (() => Promise<void>) | null = null;
@@ -146,10 +162,15 @@ export const hideReadStories = async (
 		};
 
 		const syncCheckboxVisibility = async (): Promise<void> => {
-			if (!(await getShowHiddenStoriesOptionPreference())) {
+			const [showHiddenStoriesOption, readStoriesVisibility] = await Promise.all([
+				getShowHiddenStoriesOptionPreference(),
+				getReadStoriesVisibilityPreference(),
+			]);
+
+			if (!showHiddenStoriesOption) {
 				cleanupCheckbox();
 				const readStories = await getVisitedStories(service, storyData.hnStories);
-				showStories(readStories);
+				applyReadStoriesVisibility(readStories, readStoriesVisibility);
 				return;
 			}
 
@@ -204,7 +225,8 @@ export const hideReadStoriesOnce = async (storyData: StoryData): Promise<void> =
 		if (!readStories) {
 			return;
 		}
-		hideStories(readStories);
+		const visibility = await getReadStoriesVisibilityPreference();
+		applyReadStoriesVisibility(readStories, visibility);
 	} catch (e) {
 		console.error({ error: 'Error in hideReadStoriesOnce', e });
 	}

--- a/src/components/story/hn-story.ts
+++ b/src/components/story/hn-story.ts
@@ -2,6 +2,10 @@ import type { Browser } from '#imports';
 import { STORY_HIDDEN } from '@/components/story/hide-read-stories.ts';
 import { focusClass1, focusClass2, focusClass3 } from '@/components/story/story-data.ts';
 import { paths } from '@/utils/paths.ts';
+import {
+	READ_STORIES_VISIBILITY,
+	type ReadStoriesVisibilityPreference,
+} from '@/utils/preferences.ts';
 
 const POINTS_REGEX = /^(\d+)\s+points?$/;
 const COMMENTS_REGEX = /^(\d+)\s+comments?$/;
@@ -10,6 +14,8 @@ const UPVOTE_ARROW = 'div.votearrow[title="upvote"]';
 const FAVORITE_LINK = 'button.oj_favorite_link';
 const FLAG_LINK = 'a[href^="flag?"]';
 const STORY_ID_ATTR = 'data-story-id';
+const TITLE_LINK_SELECTOR = 'span.titleline > a';
+const DIMMED_TITLE_OPACITY = '0.45';
 
 export class HNStory {
 	id: string;
@@ -67,7 +73,7 @@ export class HNStory {
 	}
 
 	parseTitle(row: HTMLElement): { title: string; url: string } {
-		const titleLink = row.querySelector<HTMLAnchorElement>('span.titleline > a');
+		const titleLink = row.querySelector<HTMLAnchorElement>(TITLE_LINK_SELECTOR);
 		const href = titleLink?.getAttribute('href') || '';
 		const url = href.length === 0 || href.startsWith('http') ? href : `${paths.base}/${href}`;
 		return {
@@ -137,6 +143,39 @@ export class HNStory {
 
 	hidden(): boolean {
 		return this.isHidden;
+	}
+
+	resetReadPresentation(): void {
+		this.show();
+
+		const titleLink = this.storyRow.querySelector<HTMLAnchorElement>(TITLE_LINK_SELECTOR);
+		if (!titleLink) {
+			return;
+		}
+
+		titleLink.style.opacity = '';
+		titleLink.style.textDecoration = '';
+	}
+
+	applyReadStoriesVisibility(visibility: ReadStoriesVisibilityPreference): void {
+		this.resetReadPresentation();
+
+		if (visibility === READ_STORIES_VISIBILITY.HIDE) {
+			this.hide();
+			return;
+		}
+
+		const titleLink = this.storyRow.querySelector<HTMLAnchorElement>(TITLE_LINK_SELECTOR);
+		if (!titleLink) {
+			return;
+		}
+
+		if (visibility === READ_STORIES_VISIBILITY.STRIKETHROUGH) {
+			titleLink.style.textDecoration = 'line-through';
+			return;
+		}
+
+		titleLink.style.opacity = DIMMED_TITLE_OPACITY;
 	}
 
 	activate() {

--- a/src/entrypoints/popup/App.css
+++ b/src/entrypoints/popup/App.css
@@ -79,6 +79,41 @@
 	gap: 12px;
 }
 
+.oj-popup__group {
+	display: grid;
+	gap: 10px;
+	padding: 14px;
+	background: color-mix(
+		in srgb,
+		var(--popup-accent-soft) 55%,
+		var(--popup-surface) 45%
+	);
+	border: 1px solid var(--popup-border);
+	border-radius: 14px;
+}
+
+.oj-popup__group-title {
+	margin: 0;
+	font-size: 0.8rem;
+	font-weight: 700;
+	line-height: 1.2;
+	color: var(--popup-accent);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.oj-popup__group-description {
+	margin: 0;
+	font-size: 0.84rem;
+	line-height: 1.35;
+	color: var(--popup-muted);
+}
+
+.oj-popup__group-settings {
+	display: grid;
+	gap: 10px;
+}
+
 .oj-popup__toggle {
 	display: flex;
 	gap: 16px;
@@ -158,4 +193,26 @@
 .oj-popup__checkbox:checked::after {
 	border-color: #fff;
 	transform: translateY(-1px) rotate(45deg) scale(1);
+}
+
+.oj-popup__select {
+	flex: 0 0 auto;
+	min-width: 136px;
+	padding: 8px 12px;
+	font: inherit;
+	color: var(--popup-text);
+	background: var(--popup-surface);
+	border: 1px solid
+		color-mix(in srgb, var(--popup-border) 75%, var(--popup-text) 25%);
+	border-radius: 8px;
+}
+
+.oj-popup__select:hover {
+	border-color: var(--popup-accent);
+}
+
+.oj-popup__select:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--popup-accent) 20%, transparent);
 }

--- a/src/entrypoints/popup/popup-app.test.ts
+++ b/src/entrypoints/popup/popup-app.test.ts
@@ -5,9 +5,12 @@ import { getDarkModePreference } from '@/utils/dark-mode.ts';
 import {
 	getEnableFocusBoxPreference,
 	getOpenStoryNewTabPreference,
+	getReadStoriesVisibilityPreference,
 	getShowHiddenStoriesOptionPreference,
+	READ_STORIES_VISIBILITY,
 	setEnableFocusBoxPreference,
 	setOpenStoryNewTabPreference,
+	setReadStoriesVisibilityPreference,
 	setShowHiddenStoriesOptionPreference,
 } from '@/utils/preferences.ts';
 import { renderPopupApp } from './popup-app.tsx';
@@ -19,12 +22,20 @@ vi.mock('@/utils/dark-mode.ts', () => ({
 vi.mock('@/utils/preferences.ts', () => ({
 	ENABLE_FOCUS_BOX_STORAGE_KEY: 'enableFocusBox',
 	OPEN_STORY_NEW_TAB_STORAGE_KEY: 'openStoryNewTab',
+	READ_STORIES_VISIBILITY: {
+		HIDE: 0,
+		STRIKETHROUGH: 1,
+		DIM: 2,
+	},
+	READ_STORIES_VISIBILITY_STORAGE_KEY: 'readStoriesVisibility',
 	SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY: 'showHiddenStoriesOption',
 	getEnableFocusBoxPreference: vi.fn(async () => true),
 	getOpenStoryNewTabPreference: vi.fn(async () => true),
+	getReadStoriesVisibilityPreference: vi.fn(async () => 0),
 	getShowHiddenStoriesOptionPreference: vi.fn(async () => true),
 	setEnableFocusBoxPreference: vi.fn(async () => {}),
 	setOpenStoryNewTabPreference: vi.fn(async () => {}),
+	setReadStoriesVisibilityPreference: vi.fn(async () => {}),
 	setShowHiddenStoriesOptionPreference: vi.fn(async () => {}),
 }));
 
@@ -98,6 +109,32 @@ describe('renderPopupApp', () => {
 		expect(getOpenStoryNewTabPreference).toHaveBeenCalledTimes(1);
 	});
 
+	it('loads the read stories visibility preference into the dropdown', async () => {
+		vi.mocked(getReadStoriesVisibilityPreference).mockResolvedValueOnce(
+			READ_STORIES_VISIBILITY.STRIKETHROUGH
+		);
+		const root = document.createElement('div');
+
+		await renderPopupApp(document, root);
+
+		const select = root.querySelector<HTMLSelectElement>(
+			'select[name="readStoriesVisibility"]'
+		);
+		expect(select?.value).toBe(String(READ_STORIES_VISIBILITY.STRIKETHROUGH));
+		expect(getReadStoriesVisibilityPreference).toHaveBeenCalledTimes(1);
+	});
+
+	it('groups the read stories settings together', async () => {
+		const root = document.createElement('div');
+
+		await renderPopupApp(document, root);
+
+		const group = root.querySelector<HTMLElement>('.oj-popup__group');
+		expect(group?.querySelector('.oj-popup__group-title')?.textContent).toBe('Read stories');
+		expect(group?.querySelector('input[name="showHiddenStoriesOption"]')).not.toBeNull();
+		expect(group?.querySelector('select[name="readStoriesVisibility"]')).not.toBeNull();
+	});
+
 	it('persists checkbox changes', async () => {
 		const root = document.createElement('div');
 		await renderPopupApp(document, root);
@@ -158,6 +195,30 @@ describe('renderPopupApp', () => {
 			});
 		});
 		expect(setOpenStoryNewTabPreference).toHaveBeenCalledWith(false);
+	});
+
+	it('persists read stories visibility changes', async () => {
+		const root = document.createElement('div');
+		await renderPopupApp(document, root);
+
+		const select = root.querySelector<HTMLSelectElement>(
+			'select[name="readStoriesVisibility"]'
+		);
+		if (!select) {
+			throw new Error('Expected read stories visibility select to exist');
+		}
+
+		select.value = String(READ_STORIES_VISIBILITY.DIM);
+		select.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(browser.tabs.sendMessage).toHaveBeenCalledWith(123, {
+				type: 'oj:preferences-updated',
+			});
+		});
+		expect(setReadStoriesVisibilityPreference).toHaveBeenCalledWith(
+			READ_STORIES_VISIBILITY.DIM
+		);
 	});
 
 	it('skips notifying the tab when there is no active tab id', async () => {

--- a/src/entrypoints/popup/popup-app.tsx
+++ b/src/entrypoints/popup/popup-app.tsx
@@ -4,11 +4,16 @@ import {
 	ENABLE_FOCUS_BOX_STORAGE_KEY,
 	getEnableFocusBoxPreference,
 	getOpenStoryNewTabPreference,
+	getReadStoriesVisibilityPreference,
 	getShowHiddenStoriesOptionPreference,
 	OPEN_STORY_NEW_TAB_STORAGE_KEY,
+	READ_STORIES_VISIBILITY,
+	READ_STORIES_VISIBILITY_STORAGE_KEY,
+	type ReadStoriesVisibilityPreference,
 	SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY,
 	setEnableFocusBoxPreference,
 	setOpenStoryNewTabPreference,
+	setReadStoriesVisibilityPreference,
 	setShowHiddenStoriesOptionPreference,
 } from '@/utils/preferences.ts';
 import { PREFERENCES_UPDATED_MESSAGE_TYPE } from '@/utils/preferences-live.ts';
@@ -23,6 +28,27 @@ interface ToggleDefinition {
 	id: string;
 	label: string;
 }
+
+interface SelectDefinition {
+	description: string;
+	id: string;
+	label: string;
+	options: ReadonlyArray<{
+		label: string;
+		value: ReadStoriesVisibilityPreference;
+	}>;
+}
+
+interface SettingsGroupDefinition {
+	description: string;
+	title: string;
+}
+
+const READ_STORIES_VISIBILITY_OPTIONS = [
+	{ label: 'Hide', value: READ_STORIES_VISIBILITY.HIDE },
+	{ label: 'Strikethrough', value: READ_STORIES_VISIBILITY.STRIKETHROUGH },
+	{ label: 'Dim', value: READ_STORIES_VISIBILITY.DIM },
+] as const;
 
 const notifyActiveTabPreferencesUpdated = async (): Promise<void> => {
 	const tabs = await browser.tabs.query({
@@ -74,6 +100,65 @@ const createToggle = (doc: Document, toggle: ToggleDefinition): HTMLLabelElement
 	return label;
 };
 
+const createSelectSetting = (doc: Document, setting: SelectDefinition): HTMLLabelElement => {
+	const label = doc.createElement('label');
+	label.className = 'oj-popup__toggle';
+	label.htmlFor = setting.id;
+
+	const copy = doc.createElement('span');
+	copy.className = 'oj-popup__toggle-copy';
+
+	const labelText = doc.createElement('span');
+	labelText.className = 'oj-popup__toggle-title';
+	labelText.textContent = setting.label;
+
+	const hintText = doc.createElement('span');
+	hintText.className = 'oj-popup__toggle-hint';
+	hintText.textContent = setting.description;
+
+	copy.append(labelText, hintText);
+
+	const select = doc.createElement('select');
+	select.className = 'oj-popup__select';
+	select.id = setting.id;
+	select.name = setting.id;
+
+	for (const optionDefinition of setting.options) {
+		const option = doc.createElement('option');
+		option.textContent = optionDefinition.label;
+		option.value = String(optionDefinition.value);
+		select.append(option);
+	}
+
+	label.append(copy, select);
+	return label;
+};
+
+const createSettingsGroup = (
+	doc: Document,
+	group: SettingsGroupDefinition
+): {
+	container: HTMLElement;
+	settings: HTMLElement;
+} => {
+	const container = doc.createElement('section');
+	container.className = 'oj-popup__group';
+
+	const heading = doc.createElement('h2');
+	heading.className = 'oj-popup__group-title';
+	heading.textContent = group.title;
+
+	const description = doc.createElement('p');
+	description.className = 'oj-popup__group-description';
+	description.textContent = group.description;
+
+	const settings = doc.createElement('div');
+	settings.className = 'oj-popup__group-settings';
+
+	container.append(heading, description, settings);
+	return { container, settings };
+};
+
 const createPopupContent = (doc: Document): HTMLElement => {
 	const main = doc.createElement('main');
 	main.className = 'oj-popup oj-popup--light';
@@ -107,10 +192,22 @@ const createPopupContent = (doc: Document): HTMLElement => {
 	const settingsList = doc.createElement('div');
 	settingsList.className = 'oj-popup__settings';
 
+	const readStoriesGroup = createSettingsGroup(doc, {
+		description:
+			'Control whether read stories are affected on story pages and how they appear.',
+		title: 'Read stories',
+	});
+
 	const showHiddenStoriesOptionLabel = createToggle(doc, {
 		description: 'Show the hide read stories checkbox on story pages.',
 		id: SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY,
 		label: 'Show hide read stories option',
+	});
+	const readStoriesVisibilityLabel = createSelectSetting(doc, {
+		description: 'Choose how visited stories appear on story pages.',
+		id: READ_STORIES_VISIBILITY_STORAGE_KEY,
+		label: 'Read stories',
+		options: READ_STORIES_VISIBILITY_OPTIONS,
 	});
 	const focusBoxLabel = createToggle(doc, {
 		description: 'Display the orange selection box around stories and comments.',
@@ -123,7 +220,8 @@ const createPopupContent = (doc: Document): HTMLElement => {
 		label: 'Open stories in new tab',
 	});
 
-	settingsList.append(showHiddenStoriesOptionLabel, focusBoxLabel, openStoryNewTabLabel);
+	readStoriesGroup.settings.append(showHiddenStoriesOptionLabel, readStoriesVisibilityLabel);
+	settingsList.append(readStoriesGroup.container, focusBoxLabel, openStoryNewTabLabel);
 	card.append(header, settingsList);
 	main.append(card);
 	return main;
@@ -149,6 +247,23 @@ export const renderPopupApp = async (doc: Document, root: HTMLElement): Promise<
 	showHiddenStoriesOptionCheckbox.checked = await getShowHiddenStoriesOptionPreference();
 	showHiddenStoriesOptionCheckbox.addEventListener('change', async () => {
 		await setShowHiddenStoriesOptionPreference(showHiddenStoriesOptionCheckbox.checked);
+		await notifyActiveTabPreferencesUpdated();
+	});
+
+	const readStoriesVisibilitySelect = popup.querySelector<HTMLSelectElement>(
+		`#${READ_STORIES_VISIBILITY_STORAGE_KEY}`
+	);
+	if (!readStoriesVisibilitySelect) {
+		throw new Error('Read stories visibility select is missing from popup UI.');
+	}
+
+	readStoriesVisibilitySelect.value = String(await getReadStoriesVisibilityPreference());
+	readStoriesVisibilitySelect.addEventListener('change', async () => {
+		const visibility = Number.parseInt(
+			readStoriesVisibilitySelect.value,
+			10
+		) as ReadStoriesVisibilityPreference;
+		await setReadStoriesVisibilityPreference(visibility);
 		await notifyActiveTabPreferencesUpdated();
 	});
 

--- a/src/utils/preferences.test.ts
+++ b/src/utils/preferences.test.ts
@@ -4,11 +4,14 @@ import {
 	ENABLE_FOCUS_BOX_STORAGE_KEY,
 	getEnableFocusBoxPreference,
 	getOpenStoryNewTabPreference,
+	getReadStoriesVisibilityPreference,
 	getShowHiddenStoriesOptionPreference,
 	OPEN_STORY_NEW_TAB_STORAGE_KEY,
 	PREFERENCES_STORAGE_KEY,
+	READ_STORIES_VISIBILITY,
 	setEnableFocusBoxPreference,
 	setOpenStoryNewTabPreference,
+	setReadStoriesVisibilityPreference,
 	setShowHiddenStoriesOptionPreference,
 } from './preferences.ts';
 
@@ -63,6 +66,7 @@ describe('preferences', () => {
 						JSON.stringify({
 							enableFocusBox: true,
 							openStoryNewTab: true,
+							readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 							showHiddenStoriesOption: true,
 						}),
 					],
@@ -74,6 +78,7 @@ describe('preferences', () => {
 					[PREFERENCES_STORAGE_KEY]: JSON.stringify({
 						enableFocusBox: false,
 						openStoryNewTab: true,
+						readStoriesVisibility: READ_STORIES_VISIBILITY.DIM,
 						showHiddenStoriesOption: false,
 					}),
 				},
@@ -95,6 +100,7 @@ describe('preferences', () => {
 						JSON.stringify({
 							enableFocusBox: false,
 							openStoryNewTab: true,
+							readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 							showHiddenStoriesOption: true,
 						}),
 					],
@@ -115,6 +121,7 @@ describe('preferences', () => {
 						JSON.stringify({
 							enableFocusBox: true,
 							openStoryNewTab: true,
+							readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 							showHiddenStoriesOption: true,
 						}),
 					],
@@ -126,11 +133,26 @@ describe('preferences', () => {
 					[PREFERENCES_STORAGE_KEY]: JSON.stringify({
 						enableFocusBox: true,
 						openStoryNewTab: true,
+						readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 						showHiddenStoriesOption: false,
 					}),
 				},
 				reader: () => getShowHiddenStoriesOptionPreference(),
 				expectedValue: false,
+				expectedSetCalls: [],
+			},
+			{
+				name: 'reads the read stories visibility from the json body',
+				storedValues: {
+					[PREFERENCES_STORAGE_KEY]: JSON.stringify({
+						enableFocusBox: true,
+						openStoryNewTab: true,
+						readStoriesVisibility: READ_STORIES_VISIBILITY.DIM,
+						showHiddenStoriesOption: true,
+					}),
+				},
+				reader: () => getReadStoriesVisibilityPreference(),
+				expectedValue: READ_STORIES_VISIBILITY.DIM,
 				expectedSetCalls: [],
 			},
 		])('$name', async ({ storedValues, reader, expectedValue, expectedSetCalls }) => {
@@ -144,6 +166,7 @@ describe('preferences', () => {
 			mockStorage({
 				[PREFERENCES_STORAGE_KEY]: JSON.stringify({
 					enableFocusBox: false,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 					showHiddenStoriesOption: true,
 				}),
 			});
@@ -155,6 +178,7 @@ describe('preferences', () => {
 				JSON.stringify({
 					enableFocusBox: false,
 					openStoryNewTab: true,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 					showHiddenStoriesOption: true,
 				})
 			);
@@ -169,6 +193,7 @@ describe('preferences', () => {
 				expectedJson: JSON.stringify({
 					enableFocusBox: false,
 					openStoryNewTab: true,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 					showHiddenStoriesOption: true,
 				}),
 			},
@@ -178,6 +203,17 @@ describe('preferences', () => {
 				expectedJson: JSON.stringify({
 					enableFocusBox: true,
 					openStoryNewTab: false,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
+					showHiddenStoriesOption: true,
+				}),
+			},
+			{
+				name: 'updates readStoriesVisibility in the json body',
+				action: () => setReadStoriesVisibilityPreference(READ_STORIES_VISIBILITY.DIM),
+				expectedJson: JSON.stringify({
+					enableFocusBox: true,
+					openStoryNewTab: true,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.DIM,
 					showHiddenStoriesOption: true,
 				}),
 			},
@@ -187,6 +223,7 @@ describe('preferences', () => {
 				expectedJson: JSON.stringify({
 					enableFocusBox: true,
 					openStoryNewTab: true,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 					showHiddenStoriesOption: false,
 				}),
 			},
@@ -195,6 +232,7 @@ describe('preferences', () => {
 				[PREFERENCES_STORAGE_KEY]: JSON.stringify({
 					enableFocusBox: true,
 					openStoryNewTab: true,
+					readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 					showHiddenStoriesOption: true,
 				}),
 			});

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -3,17 +3,29 @@ import lStorage from '@/utils/local-storage.ts';
 export const PREFERENCES_STORAGE_KEY = 'oj_preferences';
 export const ENABLE_FOCUS_BOX_STORAGE_KEY = 'enableFocusBox';
 export const OPEN_STORY_NEW_TAB_STORAGE_KEY = 'openStoryNewTab';
+export const READ_STORIES_VISIBILITY_STORAGE_KEY = 'readStoriesVisibility';
 export const SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY = 'showHiddenStoriesOption';
+
+export const READ_STORIES_VISIBILITY = {
+	HIDE: 0,
+	STRIKETHROUGH: 1,
+	DIM: 2,
+} as const;
+
+export type ReadStoriesVisibilityPreference =
+	(typeof READ_STORIES_VISIBILITY)[keyof typeof READ_STORIES_VISIBILITY];
 
 export interface Preferences {
 	enableFocusBox: boolean;
 	openStoryNewTab: boolean;
+	readStoriesVisibility: ReadStoriesVisibilityPreference;
 	showHiddenStoriesOption: boolean;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
 	enableFocusBox: true,
 	openStoryNewTab: true,
+	readStoriesVisibility: READ_STORIES_VISIBILITY.HIDE,
 	showHiddenStoriesOption: true,
 };
 
@@ -23,6 +35,16 @@ const getDefaultPreferences = (): Preferences => ({
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
 	return typeof value === 'object' && value !== null;
+};
+
+const isReadStoriesVisibilityPreference = (
+	value: unknown
+): value is ReadStoriesVisibilityPreference => {
+	return (
+		value === READ_STORIES_VISIBILITY.HIDE ||
+		value === READ_STORIES_VISIBILITY.STRIKETHROUGH ||
+		value === READ_STORIES_VISIBILITY.DIM
+	);
 };
 
 const parseStoredPreferences = (stored: string): Partial<Preferences> | null => {
@@ -38,6 +60,9 @@ const parseStoredPreferences = (stored: string): Partial<Preferences> | null => 
 		}
 		if (typeof parsed[OPEN_STORY_NEW_TAB_STORAGE_KEY] === 'boolean') {
 			preferences.openStoryNewTab = parsed[OPEN_STORY_NEW_TAB_STORAGE_KEY];
+		}
+		if (isReadStoriesVisibilityPreference(parsed[READ_STORIES_VISIBILITY_STORAGE_KEY])) {
+			preferences.readStoriesVisibility = parsed[READ_STORIES_VISIBILITY_STORAGE_KEY];
 		}
 		if (typeof parsed[SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY] === 'boolean') {
 			preferences.showHiddenStoriesOption = parsed[SHOW_HIDDEN_STORIES_OPTION_STORAGE_KEY];
@@ -60,6 +85,7 @@ const hasAllPreferences = (preferences: Partial<Preferences>): preferences is Pr
 	return (
 		typeof preferences.enableFocusBox === 'boolean' &&
 		typeof preferences.openStoryNewTab === 'boolean' &&
+		isReadStoriesVisibilityPreference(preferences.readStoriesVisibility) &&
 		typeof preferences.showHiddenStoriesOption === 'boolean'
 	);
 };
@@ -143,8 +169,20 @@ export const getOpenStoryNewTabPreference = async (): Promise<boolean> => {
 	return preferences.openStoryNewTab;
 };
 
+export const getReadStoriesVisibilityPreference =
+	async (): Promise<ReadStoriesVisibilityPreference> => {
+		const preferences = await getPreferences();
+		return preferences.readStoriesVisibility;
+	};
+
 export const setOpenStoryNewTabPreference = async (enabled: boolean): Promise<void> => {
 	await setPreference('openStoryNewTab', enabled);
+};
+
+export const setReadStoriesVisibilityPreference = async (
+	visibility: ReadStoriesVisibilityPreference
+): Promise<void> => {
+	await setPreference('readStoriesVisibility', visibility);
 };
 
 export const getShowHiddenStoriesOptionPreference = async (): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- add a popup read stories visibility preference with hide, strikethrough, and dim modes
- keep the page-level hide read stories checkbox as the on/off switch while using the dropdown to control display mode
- group the read stories preferences together and add end-to-end test coverage for storage, popup UI, and story-page behavior

Fixes #17