### PR TITLE
fix(submit): show title fetch loading state

### DIFF
--- a/src/components/submit/fetch-title.test.ts
+++ b/src/components/submit/fetch-title.test.ts
@@ -110,4 +110,57 @@ describe('fetchTitle', () => {
 
 		expect(mockContext.onInvalidated).toHaveBeenCalledWith(expect.any(Function));
 	});
+
+	it('should show a loading state while fetching the title', async () => {
+		let resolveFetch: (value: { title: string }) => void;
+		const fetchPromise = new Promise<{ title: string }>((resolve) => {
+			resolveFetch = resolve;
+		});
+		mockFetchJson.mockReturnValue(fetchPromise);
+
+		fetchTitle(mockContext, mockDoc);
+
+		const urlInput = mockDoc.querySelector<HTMLInputElement>('input[name="url"]');
+		const button = urlInput?.parentElement?.querySelector<HTMLButtonElement>('button');
+		if (!(urlInput && button)) {
+			throw new Error('Required elements not found');
+		}
+
+		urlInput.value = 'example.com';
+		button.click();
+
+		expect(button.disabled).toBe(true);
+		expect(button.innerText).toBe('fetching...');
+
+		// @ts-expect-error promise resolver is initialized synchronously in this test
+		resolveFetch({ title: 'Loaded Title' });
+		await vi.waitFor(() => {
+			expect(button.disabled).toBe(false);
+		});
+		expect(button.innerText).toBe('fetch title');
+	});
+
+	it('should dispatch an input event after populating the fetched title', async () => {
+		mockFetchJson.mockResolvedValue({ title: 'Fetched Title' });
+
+		fetchTitle(mockContext, mockDoc);
+
+		const urlInput = mockDoc.querySelector<HTMLInputElement>('input[name="url"]');
+		const titleInput = mockDoc.querySelector<HTMLInputElement>('input[name="title"]');
+		const button = urlInput?.parentElement?.querySelector<HTMLButtonElement>('button');
+		if (!(urlInput && titleInput && button)) {
+			throw new Error('Required elements not found');
+		}
+
+		const inputListener = vi.fn();
+		titleInput.addEventListener('input', inputListener);
+		urlInput.value = 'example.com';
+
+		button.click();
+
+		await vi.waitFor(() => {
+			expect(titleInput.value).toBe('Fetched Title');
+		});
+		expect(inputListener).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/components/submit/fetch-title.ts
+++ b/src/components/submit/fetch-title.ts
@@ -6,8 +6,11 @@ interface Title {
 	title: string;
 }
 
-export const fetchTitle = (ctx: ContentScriptContext, doc: Document) => {
-	const titleInput = document.querySelector<HTMLInputElement>('input[name="title"]');
+const FETCH_TITLE_LABEL = 'fetch title';
+const FETCHING_TITLE_LABEL = 'fetching...';
+
+export const fetchTitle = (ctx: ContentScriptContext, doc: Document): void => {
+	const titleInput = doc.querySelector<HTMLInputElement>('input[name="title"]');
 	if (!titleInput) {
 		return;
 	}
@@ -25,12 +28,13 @@ export const fetchTitle = (ctx: ContentScriptContext, doc: Document) => {
 	const fetchTitleBtn = doc.createElement('button');
 	fetchTitleBtn.style.paddingLeft = '10px';
 	fetchTitleBtn.classList.add('oj_link_button');
-	fetchTitleBtn.innerText = 'fetch title';
+	fetchTitleBtn.innerText = FETCH_TITLE_LABEL;
 
-	const fetchTitleHandler = async (e: Event) => {
+	const fetchTitleHandler = async (e: Event): Promise<void> => {
 		e.stopPropagation();
 		e.preventDefault();
 		fetchTitleBtn.disabled = true;
+		fetchTitleBtn.innerText = FETCHING_TITLE_LABEL;
 
 		try {
 			let { value } = urlInput;
@@ -51,10 +55,12 @@ export const fetchTitle = (ctx: ContentScriptContext, doc: Document) => {
 
 			const title = result as Title;
 			titleInput.value = title.title;
+			titleInput.dispatchEvent(new Event('input', { bubbles: true }));
 		} catch (e) {
 			console.error('Error fetching title:', e);
 		} finally {
 			fetchTitleBtn.disabled = false;
+			fetchTitleBtn.innerText = FETCH_TITLE_LABEL;
 		}
 	};
 	fetchTitleBtn.addEventListener('click', fetchTitleHandler);


### PR DESCRIPTION
Closes #9

## Summary
- show a loading state while submit-page title fetching is in progress
- dispatch input after populating the fetched title so the remaining counter updates
- cover both behaviors with submit-page tests

## Testing
- bun run test src/components/submit/fetch-title.test.ts src/components/submit/remaining.test.ts
- bun run check
- bun run compile