### PR TITLE
feat: add muted users feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
         run: bun run ci
 
   codeql:
-    needs: test
     # Only run on push to main, and not on the bump commit (and not if CI was intentionally skipped)
     if: >
       github.event_name == 'push' &&
@@ -81,7 +80,7 @@ jobs:
     uses: ./.github/workflows/codeql.yml
 
   release:
-    needs: codeql
+    needs: [test, test-latest, codeql]
     # Only run on push to main, and not on the bump commit (and not if CI was intentionally skipped)
     if: >
       github.event_name == 'push' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -65,13 +63,8 @@ jobs:
         run: bun run ci
 
   codeql:
-    # Only run on push to main, and not on the bump commit (and not if CI was intentionally skipped)
-    if: >
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
-      github.actor != 'github-actions[bot]' &&
-      !contains(github.event.head_commit.message, 'chore: bump version') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+    # Run in parallel with tests on PRs
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       actions: read
@@ -81,13 +74,11 @@ jobs:
 
   release:
     needs: [test, test-latest, codeql]
-    # Only run on push to main, and not on the bump commit (and not if CI was intentionally skipped)
+    # Only run when a PR is closed (merged) on main
     if: >
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
-      github.actor != 'github-actions[bot]' &&
-      !contains(github.event.head_commit.message, 'chore: bump version') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
     permissions:
       contents: write
       id-token: write

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Add a "favorite" button to comments and stories across various pages of HN, allo
 - **Dedicated `/following` page**: Open a combined feed of recent comments and submissions from the users you follow, rendered in the normal HN style.
 - **Comment context included**: Comment entries show the parent story title, quick links for reply/comments, and relative timestamps so you can decide what to open next faster.
 - **Local persistence and controls**: Followed-user order, expanded/collapsed sections, and recent fetched data are stored locally. Reorder the usernames by dragging, collapse noisy users by default, and refresh a single user when you want fresh data without reloading everything else.
-- **Mute users**: From the `/following` page or any user profile, you can mute noisy users. Muted comments appear faded in thread pages, and a mute/unmute toggle appears on your own profile for easy management.
 
 ## Hide read stories
 There is a checkbox displayed at the top of story pages that hides any stories you've already read. It uses the browser's history API to determine if a link has been visited before.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ There are a number of urls which are not exposed in the regular HN ux. Add a 'mo
 
 ## Enhanced User/Profile UX
 - **User Info on Hover**: Hover over any username to see a popup with user details including account creation date, karma, number of submissions, and their about section. New users (less than 1 month old) are highlighted in green. The popup stays open when you move your mouse over it, making it easy to click links in the about section.
+- **Mute users from hover cards**: The user hover popup now includes a mute toggle. Muted usernames are stored locally as an array in local storage, and their comments are styled like dead comments on thread pages so noisy users fade into the background without altering the underlying page data.
 - **Profile Links Dropdown**: Click on your username in the top navigation to reveal a dropdown menu with quick access to your profile, submissions, comments, hidden items, upvoted items, and favorites. The menu allows you to navigate to any of your profile pages without leaving the current page.
 - **Profile about clickable links**: In the about section for a user, if they have put links in, make them clickable.
 - **Load top leaders karma**: On the /leaders page, show the karma for the top 10

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Add a "favorite" button to comments and stories across various pages of HN, allo
 - **Dedicated `/following` page**: Open a combined feed of recent comments and submissions from the users you follow, rendered in the normal HN style.
 - **Comment context included**: Comment entries show the parent story title, quick links for reply/comments, and relative timestamps so you can decide what to open next faster.
 - **Local persistence and controls**: Followed-user order, expanded/collapsed sections, and recent fetched data are stored locally. Reorder the usernames by dragging, collapse noisy users by default, and refresh a single user when you want fresh data without reloading everything else.
+- **Mute users**: From the `/following` page or any user profile, you can mute noisy users. Muted comments appear faded in thread pages, and a mute/unmute toggle appears on your own profile for easy management.
 
 ## Hide read stories
 There is a checkbox displayed at the top of story pages that hides any stories you've already read. It uses the browser's history API to determine if a link has been visited before.

--- a/docs/index.html
+++ b/docs/index.html
@@ -191,8 +191,8 @@
 							<p class="why-badge">Following</p>
 							<h3 class="feature-title">Track people, not just threads</h3>
 							<p class="feature-desc">
-								Follow HN users, open a combined activity feed, and keep it ordered
-								the way you read.
+								Follow HN users, open a combined activity feed, and mute noisy users
+								so their comments fade into the background.
 							</p>
 						</article>
 						<article class="why-card">

--- a/src/components/comment/change-dead-comments-color.test.ts
+++ b/src/components/comment/change-dead-comments-color.test.ts
@@ -20,13 +20,13 @@ describe('change-dead-comments-color', () => {
 		comment.innerHTML = `
 			<span class="comhead">user [dead]</span>
 			<div class="comment">
-				<span class="commtext cdd">This is a dead comment</span>
+				<div class="commtext cdd">This is a dead comment</div>
 			</div>
 		`;
 
 		changeDeadCommentsColor(doc, [comment]);
 
-		const commtext = comment.querySelector('div.comment span.commtext.cdd');
+		const commtext = comment.querySelector('div.comment .commtext.cdd');
 		expect(commtext?.classList.contains('oj_dead_comment')).toBe(true);
 	});
 
@@ -36,13 +36,13 @@ describe('change-dead-comments-color', () => {
 		comment.innerHTML = `
 			<span class="comhead">user</span>
 			<div class="comment">
-				<span class="commtext cdd">This is a live comment</span>
+				<div class="commtext cdd">This is a live comment</div>
 			</div>
 		`;
 
 		changeDeadCommentsColor(doc, [comment]);
 
-		const commtext = comment.querySelector('div.comment span.commtext.cdd');
+		const commtext = comment.querySelector('div.comment .commtext.cdd');
 		expect(commtext?.classList.contains('oj_dead_comment')).toBe(false);
 	});
 
@@ -53,7 +53,7 @@ describe('change-dead-comments-color', () => {
 		deadComment.innerHTML = `
 			<span class="comhead">user1 [dead]</span>
 			<div class="comment">
-				<span class="commtext cdd">Dead comment</span>
+				<div class="commtext cdd">Dead comment</div>
 			</div>
 		`;
 
@@ -61,7 +61,7 @@ describe('change-dead-comments-color', () => {
 		liveComment.innerHTML = `
 			<span class="comhead">user2</span>
 			<div class="comment">
-				<span class="commtext cdd">Live comment</span>
+				<div class="commtext cdd">Live comment</div>
 			</div>
 		`;
 
@@ -69,15 +69,15 @@ describe('change-dead-comments-color', () => {
 		anotherDeadComment.innerHTML = `
 			<span class="comhead">user3 [dead]</span>
 			<div class="comment">
-				<span class="commtext cdd">Another dead comment</span>
+				<div class="commtext cdd">Another dead comment</div>
 			</div>
 		`;
 
 		changeDeadCommentsColor(doc, [deadComment, liveComment, anotherDeadComment]);
 
-		const deadCommtext1 = deadComment.querySelector('div.comment span.commtext.cdd');
-		const liveCommtext = liveComment.querySelector('div.comment span.commtext.cdd');
-		const deadCommtext2 = anotherDeadComment.querySelector('div.comment span.commtext.cdd');
+		const deadCommtext1 = deadComment.querySelector('div.comment .commtext.cdd');
+		const liveCommtext = liveComment.querySelector('div.comment .commtext.cdd');
+		const deadCommtext2 = anotherDeadComment.querySelector('div.comment .commtext.cdd');
 
 		expect(deadCommtext1?.classList.contains('oj_dead_comment')).toBe(true);
 		expect(liveCommtext?.classList.contains('oj_dead_comment')).toBe(false);
@@ -89,13 +89,13 @@ describe('change-dead-comments-color', () => {
 		const comment = doc.createElement('div');
 		comment.innerHTML = `
 			<div class="comment">
-				<span class="commtext cdd">Comment without comhead</span>
+				<div class="commtext cdd">Comment without comhead</div>
 			</div>
 		`;
 
 		changeDeadCommentsColor(doc, [comment]);
 
-		const commtext = comment.querySelector('div.comment span.commtext.cdd');
+		const commtext = comment.querySelector('div.comment .commtext.cdd');
 		expect(commtext?.classList.contains('oj_dead_comment')).toBe(false);
 	});
 

--- a/src/components/comment/change-dead-comments-color.ts
+++ b/src/components/comment/change-dead-comments-color.ts
@@ -17,7 +17,7 @@ export const changeDeadCommentsColor = (doc: Document, comments: HTMLElement[]):
 	for (const comment of comments) {
 		const commentHeadSpan = comment.querySelector<HTMLSpanElement>('span.comhead');
 		if (commentHeadSpan?.innerText.includes('[dead]')) {
-			comment.querySelector('div.comment span.commtext.cdd')?.classList.add(OJ_DEAD_COMMENT);
+			comment.querySelector('div.comment .commtext.cdd')?.classList.add(OJ_DEAD_COMMENT);
 		}
 	}
 };

--- a/src/components/comment/hn-comment.test.ts
+++ b/src/components/comment/hn-comment.test.ts
@@ -60,7 +60,16 @@ describe('HNComment', () => {
 			const comment = new HNComment(row);
 
 			expect(comment.author).toBe('alice');
+			expect(comment.getAuthor()).toBe('alice');
 			expect(comment.postedDate).toBe('2024-01-01');
+		});
+
+		it('should return a trimmed author', () => {
+			const row = createCommentRow({ author: ' alice ' });
+
+			const comment = new HNComment(row);
+
+			expect(comment.getAuthor()).toBe('alice');
 		});
 
 		it('should mark collapsed when coll or noshow class exists', () => {
@@ -77,6 +86,98 @@ describe('HNComment', () => {
 			const comment = new HNComment(row);
 
 			expect(comment.isDead).toBe(true);
+		});
+
+		it('should expose comment head and text nodes', () => {
+			const row = doc.createElement('tr');
+			row.id = 'comment-2';
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="hnuser" href="user?id=alice">alice</a>
+						<span class="dead">[dead]</span>
+					</span>
+					<div class="comment">
+						<span class="commtext">hello</span>
+					</div>
+				</td>
+			`;
+			doc.body.append(row);
+
+			const comment = new HNComment(row);
+
+			expect(comment.commentHead?.classList.contains('comhead')).toBe(true);
+			expect(comment.commentText?.classList.contains('commtext')).toBe(true);
+			expect(comment.isDead).toBe(true);
+		});
+
+		it('should expose comment text when commtext is a div', () => {
+			const row = doc.createElement('tr');
+			row.id = 'comment-5';
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="hnuser" href="user?id=alice">alice</a>
+					</span>
+					<div class="comment">
+						<div class="commtext c00">hello</div>
+					</div>
+				</td>
+			`;
+			doc.body.append(row);
+
+			const comment = new HNComment(row);
+
+			expect(comment.commentText?.tagName).toBe('DIV');
+			expect(comment.commentText?.classList.contains('commtext')).toBe(true);
+		});
+
+		it('should add muted presentation for muted comments', () => {
+			const row = doc.createElement('tr');
+			row.id = 'comment-3';
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="hnuser" href="user?id=alice">alice</a>
+					</span>
+					<div class="comment">
+						<span class="commtext">hello</span>
+					</div>
+				</td>
+			`;
+			doc.body.append(row);
+
+			const comment = new HNComment(row);
+			comment.setMuted(true);
+
+			expect(comment.mutedMarker?.textContent).toContain('[muted]');
+			expect(comment.mutedMarker?.textContent).toBe(' [muted] ');
+		});
+
+		it('should remove the muted marker when unmuting', () => {
+			const row = doc.createElement('tr');
+			row.id = 'comment-4';
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="hnuser" href="user?id=alice">alice</a>
+					</span>
+					<div class="comment">
+						<span class="commtext">hello</span>
+					</div>
+				</td>
+			`;
+			doc.body.append(row);
+
+			const comment = new HNComment(row);
+			comment.setMuted(true);
+			comment.setMuted(false);
+
+			expect(comment.mutedMarker).toBeNull();
 		});
 
 		it('should set data-comment-id attribute', () => {

--- a/src/components/comment/hn-comment.ts
+++ b/src/components/comment/hn-comment.ts
@@ -16,12 +16,17 @@ const COMMENT_ID_ATTR = 'data-comment-id';
 export const focusClass = 'oj_focused_comment';
 export const focusClassDefault = 'oj_focused_comment_default';
 
+const MUTED_MARKER_TEXT = ' [muted] ';
+const MUTED_MARKER_STYLE_ID = 'oj-muted-marker-style';
+
 export class HNComment {
 	id: string;
 	commentRow: HTMLElement;
 
 	author?: string;
 	postedDate?: string;
+	mutedMarker: HTMLElement | null = null;
+	private mutedMarkerInserted = false;
 
 	constructor(commentRow: HTMLElement) {
 		this.id = commentRow.id;
@@ -34,6 +39,53 @@ export class HNComment {
 		this.author = this.commentRow.querySelector('a.hnuser')?.textContent || undefined;
 		this.postedDate =
 			this.commentRow.querySelector('span.age')?.getAttribute('title') || undefined;
+		this.ensureMutedMarkerStyle();
+	}
+
+	get commentHead(): HTMLElement | null {
+		return this.commentRow.querySelector('.comhead');
+	}
+
+	get commentText(): HTMLElement | null {
+		return this.commentRow.querySelector('.commtext');
+	}
+
+	getAuthor(): string | undefined {
+		return this.author?.trim();
+	}
+
+	setMuted(muted: boolean): void {
+		if (muted && !this.mutedMarkerInserted) {
+			const authorLink = this.commentHead?.querySelector('a.hnuser');
+			if (authorLink) {
+				const marker = document.createElement('span');
+				marker.className = 'oj_muted_marker';
+				marker.textContent = MUTED_MARKER_TEXT;
+				authorLink.after(marker);
+				this.mutedMarker = marker;
+				this.mutedMarkerInserted = true;
+			}
+		} else if (!muted && this.mutedMarker) {
+			this.mutedMarker.remove();
+			this.mutedMarker = null;
+			this.mutedMarkerInserted = false;
+		}
+	}
+
+	private ensureMutedMarkerStyle(): void {
+		if (document.getElementById(MUTED_MARKER_STYLE_ID)) {
+			return;
+		}
+		const style = document.createElement('style');
+		style.id = MUTED_MARKER_STYLE_ID;
+		style.textContent = `
+			.hnuser + ${JSON.stringify(MUTED_MARKER_TEXT)} {
+				color: #888;
+				font-size: 0.85em;
+				margin-left: 4px;
+			}
+		`;
+		document.head.appendChild(style);
 	}
 
 	get isCollapsed(): boolean {
@@ -100,16 +152,11 @@ export class HNComment {
 			VOTE_SELECTORS.UNVOTE_LINK
 		) as HTMLAnchorElement;
 
-		if (unvoteBtn) {
-			unvoteBtn.click();
+		const btn = unvoteBtn ?? voteBtn;
+		if (btn) {
+			btn.click();
 			return true;
 		}
-
-		if (voteBtn) {
-			voteBtn.click();
-			return true;
-		}
-
 		return false;
 	}
 

--- a/src/components/comment/index.ts
+++ b/src/components/comment/index.ts
@@ -12,10 +12,12 @@ import { indentToggle } from '@/components/comment/indent-toggle.ts';
 import { initCommentUX } from '@/components/comment/init-comment-ux.ts';
 import { inlineReply } from '@/components/comment/inline-reply.ts';
 import { keyboardNavigation } from '@/components/comment/keyboard-navigation.ts';
+import { applyMutedComments } from '@/components/comment/muted-comments.ts';
 import { replyFocusTextarea } from '@/components/comment/reply-focus.ts';
 import { getNavState } from '@/components/common/index.ts';
 import { createClientServices } from '@/services/manager.ts';
 import { dom } from '@/utils/dom.ts';
+import { getMutedUsers } from '@/utils/muted-users.ts';
 import { paths } from '@/utils/paths.ts';
 import type { ComponentFeature } from '@/utils/types.ts';
 
@@ -26,7 +28,7 @@ export const comments: ComponentFeature = {
 	loginRequired: true,
 	matches: [`${paths.base}/*`],
 	runAt: 'document_end',
-	main(ctx: ContentScriptContext) {
+	async main(ctx: ContentScriptContext) {
 		if (!validPaths.some((p) => document.location.pathname.startsWith(p))) {
 			return;
 		}
@@ -37,9 +39,11 @@ export const comments: ComponentFeature = {
 		const itemAuthor = dom.getItemAuthor(document);
 		const hnComments = allComments.map((el) => new HNComment(el));
 		const commentData = new CommentData(hnComments);
+		const mutedUsers = await getMutedUsers();
 
 		return Promise.all([
 			Promise.resolve().then(() => initCommentUX(document, allComments, itemAuthor)),
+			Promise.resolve().then(() => applyMutedComments(document, hnComments, mutedUsers)),
 			Promise.resolve().then(() => highlightUnreadComments(document, allComments, manager)),
 			Promise.resolve().then(() => persistCollapsedComments(ctx, allComments)),
 			Promise.resolve().then(() => indentToggle(ctx, document, allComments)),

--- a/src/components/comment/muted-comments.test.ts
+++ b/src/components/comment/muted-comments.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { HNComment } from '@/components/comment/hn-comment.ts';
+import { applyMutedComments, OJ_MUTED_COMMENT } from './muted-comments.ts';
+
+const createComment = (doc: Document, username: string, body: string): HTMLElement => {
+	const comment = doc.createElement('div');
+	comment.innerHTML = `
+		<span class="comhead">
+			<a class="hnuser" href="user?id=${username}">${username}</a>
+		</span>
+		<div class="comment">
+			<span class="commtext">${body}</span>
+		</div>
+	`;
+	return comment;
+};
+
+const createHNComment = (doc: Document, username: string, body: string): HNComment => {
+	const comment = createComment(doc, username, body);
+	comment.id = username;
+	return new HNComment(comment);
+};
+
+describe('muted-comments', () => {
+	it('adds muted comment styles to the document head', () => {
+		const doc = document.implementation.createHTMLDocument();
+
+		applyMutedComments(doc, [], []);
+
+		const styleElement = doc.head.querySelector('style');
+		expect(styleElement).not.toBeNull();
+		expect(styleElement?.textContent).toContain(`.${OJ_MUTED_COMMENT}`);
+		expect(styleElement?.textContent).toContain('--oj-muted-comment-color');
+		expect(styleElement?.textContent).toContain('#8b8276');
+		expect(styleElement?.textContent).toContain('#9a9082');
+	});
+
+	it('adds the muted class to comments whose authors are muted', () => {
+		const doc = document.implementation.createHTMLDocument();
+		const mutedComment = createHNComment(doc, 'pg', 'Muted body');
+		const liveComment = createHNComment(doc, 'dang', 'Live body');
+
+		applyMutedComments(doc, [mutedComment, liveComment], ['pg']);
+
+		expect(mutedComment.commentRow.classList.contains(OJ_MUTED_COMMENT)).toBe(true);
+		expect(
+			mutedComment.commentRow.querySelector('.commtext')?.classList.contains(OJ_MUTED_COMMENT)
+		).toBe(true);
+		expect(
+			mutedComment.commentRow.querySelector('.comhead')?.classList.contains(OJ_MUTED_COMMENT)
+		).toBe(true);
+		expect(mutedComment.commentRow.querySelector('.oj_muted_marker')?.textContent).toContain(
+			'[muted]'
+		);
+		expect(liveComment.commentRow.classList.contains(OJ_MUTED_COMMENT)).toBe(false);
+		expect(
+			liveComment.commentRow.querySelector('.commtext')?.classList.contains(OJ_MUTED_COMMENT)
+		).toBe(false);
+		expect(liveComment.commentRow.querySelector('.oj_muted_marker')).toBeNull();
+	});
+
+	it('removes the muted class when a user is no longer muted', () => {
+		const doc = document.implementation.createHTMLDocument();
+		const comment = createHNComment(doc, 'pg', 'Body');
+
+		applyMutedComments(doc, [comment], ['pg']);
+		applyMutedComments(doc, [comment], []);
+
+		expect(comment.commentRow.classList.contains(OJ_MUTED_COMMENT)).toBe(false);
+		expect(
+			comment.commentRow.querySelector('.commtext')?.classList.contains(OJ_MUTED_COMMENT)
+		).toBe(false);
+		expect(comment.commentRow.querySelector('.oj_muted_marker')).toBeNull();
+	});
+
+	it('ignores comments without text bodies', () => {
+		const doc = document.implementation.createHTMLDocument();
+		const comment = doc.createElement('div');
+		comment.className = 'comtr';
+		comment.innerHTML = `
+			<span class="comhead">
+				<a class="hnuser" href="user?id=pg">pg</a>
+			</span>
+		`;
+		comment.id = 'missing-body';
+
+		expect(() => applyMutedComments(doc, [new HNComment(comment)], ['pg'])).not.toThrow();
+	});
+});

--- a/src/components/comment/muted-comments.ts
+++ b/src/components/comment/muted-comments.ts
@@ -1,0 +1,92 @@
+import type { HNComment } from '@/components/comment/hn-comment.ts';
+import { getMutedUsers } from '@/utils/muted-users.ts';
+
+export const OJ_MUTED_COMMENT = 'oj_muted_comment';
+
+const MUTED_COMMENT_STYLE_ID = 'oj-muted-comment-style';
+const MUTED_COMMENT_COLOR_LIGHT = '#8b8276';
+const MUTED_COMMENT_COLOR_DARK = '#9a9082';
+
+const ensureMutedCommentStyles = (doc: Document): void => {
+	if (doc.getElementById(MUTED_COMMENT_STYLE_ID)) {
+		return;
+	}
+
+	const style = doc.createElement('style');
+	style.id = MUTED_COMMENT_STYLE_ID;
+	style.textContent = `
+		:root {
+			--oj-muted-comment-color: ${MUTED_COMMENT_COLOR_LIGHT};
+		}
+
+		html.oj-dark-mode {
+			--oj-muted-comment-color: ${MUTED_COMMENT_COLOR_DARK};
+		}
+
+		.${OJ_MUTED_COMMENT} .comment,
+		.${OJ_MUTED_COMMENT} .comment *,
+		.${OJ_MUTED_COMMENT} .comhead,
+		.${OJ_MUTED_COMMENT} .comhead * {
+			color: var(--oj-muted-comment-color) !important;
+		}
+
+		.${OJ_MUTED_COMMENT} .oj-follow-button,
+		.${OJ_MUTED_COMMENT} .oj-follow-icon {
+			opacity: 0.55;
+		}
+
+		.${OJ_MUTED_COMMENT} code,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} code,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comment code {
+			color: var(--oj-muted-comment-color) !important;
+		}
+
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comhead a.hnuser.oj_op,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comhead,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comhead *,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comment,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .comment *,
+		html.oj-dark-mode .${OJ_MUTED_COMMENT} .oj_link_button {
+			color: var(--oj-muted-comment-color) !important;
+		}
+	`;
+	doc.head.appendChild(style);
+};
+
+export const applyMutedComments = (
+	doc: Document,
+	comments: readonly HNComment[],
+	mutedUsers: readonly string[]
+): void => {
+	ensureMutedCommentStyles(doc);
+
+	const mutedUsersSet = new Set(mutedUsers);
+	for (const comment of comments) {
+		const { commentHead, commentRow, commentText } = comment;
+		const author = comment.getAuthor();
+		const shouldMute = Boolean(
+			commentText && commentHead && author && mutedUsersSet.has(author)
+		);
+
+		if (shouldMute) {
+			commentRow.classList.add(OJ_MUTED_COMMENT);
+			commentText?.classList.add(OJ_MUTED_COMMENT);
+			commentHead?.classList.add(OJ_MUTED_COMMENT);
+			comment.setMuted(true);
+			continue;
+		}
+
+		commentRow.classList.remove(OJ_MUTED_COMMENT);
+		commentText?.classList.remove(OJ_MUTED_COMMENT);
+		commentHead?.classList.remove(OJ_MUTED_COMMENT);
+		comment.setMuted(false);
+	}
+};
+
+export const syncMutedComments = async (
+	doc: Document,
+	comments: readonly HNComment[]
+): Promise<void> => {
+	const mutedUsers = await getMutedUsers();
+	applyMutedComments(doc, comments, mutedUsers);
+};

--- a/src/components/follow/index.ts
+++ b/src/components/follow/index.ts
@@ -1359,7 +1359,10 @@ const attachButtonAfterNode = (
 	wrap.className = FOLLOW_BUTTON_CONTAINER_CLASS;
 	const button = createFollowButton(doc, username, isFollowing);
 	wrap.append(button);
-	target.parentNode.insertBefore(wrap, target.nextSibling);
+
+	const mutedMarker = target.parentNode.querySelector('.oj_muted_marker');
+	const insertBefore = mutedMarker ? mutedMarker.nextSibling : target.nextSibling;
+	target.parentNode.insertBefore(wrap, insertBefore);
 	registerButton(ctx, doc, username, buttonsByUsername, button, currentUsername);
 };
 

--- a/src/components/user/index.ts
+++ b/src/components/user/index.ts
@@ -1,4 +1,5 @@
 import type { ContentScriptContext } from '#imports';
+import { mutedUsersRow } from '@/components/user/muted-users-row.ts';
 import { profileLinksDropdown } from '@/components/user/profile-links-dropdown.ts';
 import { showUserInfoOnHover } from '@/components/user/show-user-info-hover.ts';
 import { topLeadersKarma } from '@/components/user/top-leaders-karma.ts';
@@ -15,6 +16,7 @@ export const user: ComponentFeature = {
 		return Promise.all([
 			Promise.resolve().then(() => showUserInfoOnHover(ctx, document, user.username)),
 			Promise.resolve().then(() => profileLinksDropdown(ctx, document)),
+			Promise.resolve().then(() => mutedUsersRow(ctx, document)),
 			Promise.resolve().then(() => userAboutLinkify(ctx, document)),
 			Promise.resolve().then(() => topLeadersKarma(document)),
 		]);

--- a/src/components/user/muted-users-row.test.ts
+++ b/src/components/user/muted-users-row.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ContentScriptContext } from '#imports';
+import lStorage from '@/utils/local-storage.ts';
+import { MUTED_USERS_STORAGE_KEY } from '@/utils/muted-users.ts';
+import { mutedUsersRow } from './muted-users-row.ts';
+
+const addListenerMock = vi.fn();
+const removeListenerMock = vi.fn();
+
+vi.mock('#imports', () => ({
+	browser: {
+		storage: {
+			onChanged: {
+				addListener: addListenerMock,
+				removeListener: removeListenerMock,
+			},
+		},
+	},
+}));
+
+describe('mutedUsersRow', () => {
+	let mockCtx: ContentScriptContext;
+
+	beforeEach(async () => {
+		document.body.innerHTML = '';
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, null);
+		vi.clearAllMocks();
+		addListenerMock.mockClear();
+		removeListenerMock.mockClear();
+		mockCtx = {
+			onInvalidated: vi.fn(),
+		} as unknown as ContentScriptContext;
+	});
+
+	const renderProfileForm = (options?: {
+		action?: string;
+		currentUsername?: string;
+		profileUsername?: string;
+	}): void => {
+		document.body.innerHTML = `
+			<span class="pagetop">
+				<a href="user?id=${options?.currentUsername ?? 'latchkey'}">${options?.currentUsername ?? 'latchkey'}</a>
+			</span>
+			<form action="${options?.action ?? 'xuser'}" method="post">
+				<table>
+					<tbody>
+						<tr>
+							<td>user:</td>
+							<td><a href="user?id=${options?.profileUsername ?? 'latchkey'}" class="hnuser">${options?.profileUsername ?? 'latchkey'}</a></td>
+						</tr>
+						<tr>
+							<td>about:</td>
+							<td><textarea name="about"></textarea></td>
+						</tr>
+						<tr>
+							<td></td>
+							<td><input type="submit" value="update"></td>
+						</tr>
+					</tbody>
+				</table>
+			</form>
+		`;
+	};
+
+	it('does nothing outside user pages', async () => {
+		window.history.pushState({}, '', '/threads?id=latchkey');
+		renderProfileForm();
+
+		await mutedUsersRow(mockCtx, document);
+
+		expect(document.querySelector('.oj-muted-users-row')).toBeNull();
+	});
+
+	it('appends a muted users row to the end of the profile table body', async () => {
+		window.history.pushState({}, '', '/user?id=latchkey');
+		renderProfileForm();
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, ['alice', 'bob']);
+
+		await mutedUsersRow(mockCtx, document);
+
+		const rows = Array.from(document.querySelectorAll('form[action="xuser"] tbody tr'));
+		const mutedRow = rows.at(-1);
+		if (!mutedRow) {
+			throw new Error('Expected muted users row');
+		}
+		expect(mutedRow.classList.contains('oj-muted-users-row')).toBe(true);
+		expect(mutedRow.textContent).toContain('muted:');
+		expect(mutedRow.textContent).toContain('alice');
+		expect(mutedRow.textContent).toContain('bob');
+	});
+
+	it('shows a mute action row when viewing another user profile', async () => {
+		window.history.pushState({}, '', '/user?id=pg');
+		renderProfileForm({ currentUsername: 'latchkey', profileUsername: 'pg' });
+
+		await mutedUsersRow(mockCtx, document);
+
+		const actionRow = document.querySelector('.oj-muted-users-action-row');
+		expect(actionRow?.textContent).toContain('mute:');
+		expect(actionRow?.textContent).toContain('mute');
+		expect(document.querySelector('.oj-muted-users-row')).toBeNull();
+	});
+
+	it('toggles mute state from another user profile page', async () => {
+		window.history.pushState({}, '', '/user?id=pg');
+		renderProfileForm({ currentUsername: 'latchkey', profileUsername: 'pg' });
+
+		await mutedUsersRow(mockCtx, document);
+
+		const button = document.querySelector<HTMLButtonElement>('.oj-action-button');
+		button?.click();
+
+		await vi.waitFor(() => {
+			expect(button?.textContent).toBe('unmute');
+		});
+		await expect(lStorage.getItem(MUTED_USERS_STORAGE_KEY)).resolves.toEqual(['pg']);
+	});
+
+	it('supports profile forms that use /xuser as the action', async () => {
+		window.history.pushState({}, '', '/user?id=latchkey');
+		renderProfileForm({ action: '/xuser' });
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, ['alice']);
+
+		await mutedUsersRow(mockCtx, document);
+
+		expect(document.querySelector('.oj-muted-users-row')?.textContent).toContain('alice');
+	});
+
+	it('shows none when no users are muted', async () => {
+		window.history.pushState({}, '', '/user?id=latchkey');
+		renderProfileForm();
+
+		await mutedUsersRow(mockCtx, document);
+
+		expect(document.querySelector('.oj-muted-users-row')?.textContent).toContain('none');
+	});
+
+	it('unmutes a user from the profile row', async () => {
+		window.history.pushState({}, '', '/user?id=latchkey');
+		renderProfileForm();
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, ['alice', 'bob']);
+
+		await mutedUsersRow(mockCtx, document);
+
+		const button = Array.from(
+			document.querySelectorAll<HTMLButtonElement>('.oj-action-button')
+		).find((item) => item.parentElement?.textContent?.includes('alice'));
+		button?.click();
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('.oj-muted-users-row')?.textContent).not.toContain(
+				'alice'
+			);
+			expect(document.querySelector('.oj-muted-users-row')?.textContent).toContain('bob');
+		});
+		await expect(lStorage.getItem(MUTED_USERS_STORAGE_KEY)).resolves.toEqual(['bob']);
+	});
+});

--- a/src/components/user/muted-users-row.ts
+++ b/src/components/user/muted-users-row.ts
@@ -1,0 +1,200 @@
+import type { ContentScriptContext } from '#imports';
+import { ACTION_BUTTON_CLASS, getActionButtonStyle } from '@/utils/action-button.ts';
+import lStorage from '@/utils/local-storage.ts';
+import {
+	getMutedUsers,
+	isMutedUser,
+	MUTED_USERS_STORAGE_KEY,
+	setMutedUsers,
+	toggleMutedUser,
+} from '@/utils/muted-users.ts';
+
+const MUTED_USERS_ROW_CLASS = 'oj-muted-users-row';
+const MUTED_USERS_LIST_CLASS = 'oj-muted-users-list';
+const MUTED_USERS_ITEM_CLASS = 'oj-muted-users-item';
+const MUTED_USERS_STYLE_ID = 'oj-muted-users-row-style';
+const MUTED_USERS_ACTION_ROW_CLASS = 'oj-muted-users-action-row';
+
+const ensureMutedUsersRowStyles = (doc: Document): void => {
+	if (doc.getElementById(MUTED_USERS_STYLE_ID)) {
+		return;
+	}
+
+	const style = doc.createElement('style');
+	style.id = MUTED_USERS_STYLE_ID;
+	style.textContent = `
+		.${MUTED_USERS_LIST_CLASS} {
+			display: inline-grid;
+			row-gap: 6px;
+		}
+
+		.${MUTED_USERS_ITEM_CLASS} {
+			display: grid;
+			grid-template-columns: 15ch auto;
+			align-items: center;
+			column-gap: 8px;
+			width: max-content;
+		}
+	${getActionButtonStyle()}
+	`;
+	doc.head.appendChild(style);
+};
+
+const findProfileTableBody = (doc: Document): HTMLTableSectionElement | null => {
+	for (const row of doc.querySelectorAll<HTMLTableRowElement>('tr')) {
+		const labelCell = row.querySelector<HTMLTableCellElement>('td:first-child');
+		if (labelCell?.textContent?.trim() !== 'user:') {
+			continue;
+		}
+
+		return row.closest<HTMLTableSectionElement>('tbody') ?? null;
+	}
+
+	return null;
+};
+
+const removeExistingRow = (tableBody: HTMLTableSectionElement): void => {
+	tableBody.querySelector(`.${MUTED_USERS_ROW_CLASS}`)?.remove();
+	tableBody.querySelector(`.${MUTED_USERS_ACTION_ROW_CLASS}`)?.remove();
+};
+
+const getCurrentUsername = (doc: Document): string | undefined => {
+	return (
+		doc
+			.querySelector<HTMLAnchorElement>('span.pagetop a[href*="user?id="]')
+			?.textContent?.split(' ')[0] || undefined
+	);
+};
+
+const getProfileUsername = (tableBody: HTMLTableSectionElement): string | undefined => {
+	for (const row of tableBody.querySelectorAll<HTMLTableRowElement>('tr')) {
+		const labelCell = row.querySelector<HTMLTableCellElement>('td:first-child');
+		if (labelCell?.textContent?.trim() !== 'user:') {
+			continue;
+		}
+
+		const username = row
+			.querySelector<HTMLAnchorElement>('td:last-child a.hnuser')
+			?.textContent?.trim();
+		if (username) {
+			return username;
+		}
+	}
+};
+
+const createMutedUsersContent = (
+	doc: Document,
+	usernames: readonly string[],
+	onUnmute: (username: string) => Promise<void>
+): Node => {
+	if (!usernames.length) {
+		return doc.createTextNode('none');
+	}
+
+	const fragment = doc.createDocumentFragment();
+	const list = doc.createElement('span');
+	list.className = MUTED_USERS_LIST_CLASS;
+
+	for (const username of usernames) {
+		const item = doc.createElement('span');
+		item.className = MUTED_USERS_ITEM_CLASS;
+
+		const link = doc.createElement('a');
+		link.href = `user?id=${encodeURIComponent(username)}`;
+		link.textContent = username;
+
+		const button = doc.createElement('button');
+		button.type = 'button';
+		button.className = ACTION_BUTTON_CLASS;
+		button.textContent = 'unmute';
+		button.addEventListener('click', async () => {
+			await onUnmute(username);
+		});
+
+		item.append(link, doc.createTextNode(' '), button);
+		list.append(item);
+	}
+
+	fragment.append(list);
+	return fragment;
+};
+
+export const mutedUsersRow = async (ctx: ContentScriptContext, doc: Document): Promise<void> => {
+	if (!window.location.pathname.startsWith('/user')) {
+		return;
+	}
+
+	ensureMutedUsersRowStyles(doc);
+
+	const tableBody = findProfileTableBody(doc);
+	if (!tableBody) {
+		return;
+	}
+
+	const currentUsername = getCurrentUsername(doc);
+	const profileUsername = getProfileUsername(tableBody);
+	if (!profileUsername) {
+		return;
+	}
+
+	const render = async (): Promise<void> => {
+		removeExistingRow(tableBody);
+
+		if (currentUsername && currentUsername === profileUsername) {
+			const mutedUsers = await getMutedUsers();
+			const row = doc.createElement('tr');
+			row.className = MUTED_USERS_ROW_CLASS;
+			row.style.paddingTop = '10px';
+
+			const labelCell = doc.createElement('td');
+			labelCell.textContent = 'muted:';
+			labelCell.setAttribute('valign', 'top');
+			labelCell.style.paddingTop = '10px';
+
+			const valueCell = doc.createElement('td');
+			valueCell.style.paddingTop = '10px';
+			valueCell.append(
+				createMutedUsersContent(doc, mutedUsers, async (username: string) => {
+					const nextMutedUsers = mutedUsers.filter((entry) => entry !== username);
+					await setMutedUsers(nextMutedUsers);
+					await render();
+				})
+			);
+
+			row.append(labelCell, valueCell);
+			tableBody.append(row);
+			return;
+		}
+
+		const row = doc.createElement('tr');
+		row.className = MUTED_USERS_ACTION_ROW_CLASS;
+
+		const labelCell = doc.createElement('td');
+		labelCell.textContent = 'mute:';
+		labelCell.setAttribute('valign', 'top');
+		labelCell.style.paddingTop = '10px';
+
+		const valueCell = doc.createElement('td');
+		valueCell.style.paddingTop = '10px';
+
+		const button = doc.createElement('button');
+		button.type = 'button';
+		button.className = ACTION_BUTTON_CLASS;
+		button.textContent = (await isMutedUser(profileUsername)) ? 'unmute' : 'mute';
+		button.addEventListener('click', async () => {
+			const muted = await toggleMutedUser(profileUsername);
+			button.textContent = muted ? 'unmute' : 'mute';
+		});
+
+		valueCell.append(button);
+		row.append(labelCell, valueCell);
+		tableBody.append(row);
+	};
+
+	await render();
+
+	const unwatch = lStorage.watch(MUTED_USERS_STORAGE_KEY, async () => {
+		await render();
+	});
+	ctx.onInvalidated(unwatch);
+};

--- a/src/components/user/show-user-info-hover.test.ts
+++ b/src/components/user/show-user-info-hover.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContentScriptContext } from '#imports';
+import { syncMutedComments } from '@/components/comment/muted-comments';
 import { apiModule } from '@/utils/api';
+import { isMutedUser, toggleMutedUser } from '@/utils/muted-users';
 import { showUserInfoOnHover } from './show-user-info-hover';
 
 vi.mock('@/utils/api', () => {
@@ -12,6 +14,15 @@ vi.mock('@/utils/api', () => {
 		getUserInfo,
 	};
 });
+
+vi.mock('@/utils/muted-users', () => ({
+	isMutedUser: vi.fn(),
+	toggleMutedUser: vi.fn(),
+}));
+
+vi.mock('@/components/comment/muted-comments', () => ({
+	syncMutedComments: vi.fn(),
+}));
 
 describe('showUserInfoOnHover', () => {
 	let mockCtx: ContentScriptContext;
@@ -29,6 +40,8 @@ describe('showUserInfoOnHover', () => {
 		} as unknown as ContentScriptContext;
 
 		vi.clearAllMocks();
+		vi.mocked(isMutedUser).mockResolvedValue(false);
+		vi.mocked(syncMutedComments).mockResolvedValue();
 	});
 
 	const createUserLink = (userName: string): HTMLAnchorElement => {
@@ -95,6 +108,57 @@ describe('showUserInfoOnHover', () => {
 			expect(popover?.textContent).toContain('testuser');
 			expect(popover?.textContent).toContain('5000');
 			expect(popover?.textContent).toContain('100');
+		});
+	});
+
+	it('should render a mute button next to the username', async () => {
+		const userLink = createUserLink('testuser');
+		mockUserInfo('testuser');
+
+		showUserInfoOnHover(mockCtx, document);
+
+		userLink.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			const button = document.querySelector<HTMLButtonElement>('.oj-action-button');
+			expect(button?.textContent).toBe('mute');
+		});
+	});
+
+	it('should render unmute when the user is already muted', async () => {
+		const userLink = createUserLink('testuser');
+		mockUserInfo('testuser');
+		vi.mocked(isMutedUser).mockResolvedValueOnce(true);
+
+		showUserInfoOnHover(mockCtx, document);
+
+		userLink.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			const button = document.querySelector<HTMLButtonElement>('.oj-action-button');
+			expect(button?.textContent).toBe('unmute');
+		});
+	});
+
+	it('should toggle mute state and sync comments when the mute button is clicked', async () => {
+		const userLink = createUserLink('testuser');
+		mockUserInfo('testuser');
+		vi.mocked(toggleMutedUser).mockResolvedValueOnce(true);
+
+		showUserInfoOnHover(mockCtx, document);
+
+		userLink.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('.oj-action-button')).toBeTruthy();
+		});
+		const button = document.querySelector<HTMLButtonElement>('.oj-action-button');
+		button?.click();
+
+		await vi.waitFor(() => {
+			expect(toggleMutedUser).toHaveBeenCalledWith('testuser');
+			expect(syncMutedComments).toHaveBeenCalled();
+			expect(button?.textContent).toBe('unmute');
 		});
 	});
 

--- a/src/components/user/show-user-info-hover.ts
+++ b/src/components/user/show-user-info-hover.ts
@@ -1,6 +1,11 @@
 import type { ContentScriptContext } from '#imports';
+import { HNComment } from '@/components/comment/hn-comment.ts';
+import { syncMutedComments } from '@/components/comment/muted-comments.ts';
+import { ACTION_BUTTON_CLASS, getActionButtonStyle } from '@/utils/action-button.ts';
 import { apiModule } from '@/utils/api.ts';
+import { dom } from '@/utils/dom.ts';
 import { cloneChildNodesInto, createSanitizedFragment, linkifyTextNodes } from '@/utils/html.ts';
+import { isMutedUser, toggleMutedUser } from '@/utils/muted-users.ts';
 
 const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 export const USER_INFO_HOVER_CLASS = 'oj_user_info_hover';
@@ -59,6 +64,11 @@ export const showUserInfoOnHover = (
 		.${USER_INFO_HOVER_CLASS} td {
 			vertical-align: top;
 		}
+
+		.${ACTION_BUTTON_CLASS} {
+			margin-left: 6px;
+		}
+	${getActionButtonStyle()}
 	`;
 		doc.head.appendChild(style);
 	}
@@ -73,12 +83,39 @@ export const showUserInfoOnHover = (
 	const cachedData = new Map<string, HTMLDivElement>();
 	let activeTrigger: HTMLAnchorElement | null = null;
 	let popover: HTMLDivElement | null = null;
+	const allComments = dom.getAllComments(doc);
+	const hnComments = allComments.map((comment) => new HNComment(comment));
+
+	const upsertMuteButton = async (
+		userName: string,
+		userDivBox: HTMLDivElement
+	): Promise<void> => {
+		const userRow = userDivBox.querySelector<HTMLTableRowElement>('tr');
+		const userValueCell = userRow?.querySelector<HTMLTableCellElement>('td:last-child');
+		if (!userValueCell) {
+			return;
+		}
+
+		userValueCell.querySelector(`.${ACTION_BUTTON_CLASS}`)?.remove();
+
+		const button = doc.createElement('button');
+		button.type = 'button';
+		button.className = ACTION_BUTTON_CLASS;
+		button.textContent = (await isMutedUser(userName)) ? 'unmute' : 'mute';
+		button.addEventListener('click', async () => {
+			const isMuted = await toggleMutedUser(userName);
+			button.textContent = isMuted ? 'unmute' : 'mute';
+			await syncMutedComments(doc, hnComments);
+		});
+		userValueCell.append(button);
+	};
 
 	const populateUserDiv = async (user: HTMLAnchorElement, userDivBox: HTMLDivElement) => {
 		const userName = user.innerText.trim().split(' ')[0];
 		const cachedUserDiv = cachedData.get(userName);
 		if (cachedUserDiv) {
 			cloneChildNodesInto(cachedUserDiv, userDivBox);
+			await upsertMuteButton(userName, userDivBox);
 			return;
 		}
 
@@ -133,6 +170,7 @@ export const showUserInfoOnHover = (
 
 		userDivBox.replaceChildren(table);
 		cachedData.set(userName, userDivBox.cloneNode(true) as HTMLDivElement);
+		await upsertMuteButton(userName, userDivBox);
 	};
 
 	const createUserDiv = (doc: Document) => {

--- a/src/utils/action-button.ts
+++ b/src/utils/action-button.ts
@@ -1,0 +1,51 @@
+export const ACTION_BUTTON_CLASS = 'oj-action-button';
+export const ACTION_BUTTON_STYLE_ID = 'oj-action-button-style';
+
+export const getActionButtonStyle = () => `
+	.${ACTION_BUTTON_CLASS} {
+		min-width: 72px;
+		padding: 3px 10px;
+		border: 1px solid #b8b0a4;
+		border-radius: 999px;
+		background: linear-gradient(180deg, #fffdf8 0%, #f0ece3 100%);
+		color: #5f564a;
+		font-size: 12px;
+		line-height: 1.2;
+		text-align: center;
+		cursor: pointer;
+		transition:
+			background 120ms ease,
+			border-color 120ms ease,
+			color 120ms ease,
+			transform 120ms ease,
+			box-shadow 120ms ease;
+	}
+
+	.${ACTION_BUTTON_CLASS}:hover {
+		border-color: #9e9487;
+		background: linear-gradient(180deg, #ffffff 0%, #e9e2d6 100%);
+		box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+		transform: translateY(-1px);
+	}
+
+	.${ACTION_BUTTON_CLASS}:active {
+		transform: translateY(0);
+		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+	}
+
+	html.oj-dark-mode .${ACTION_BUTTON_CLASS} {
+		border-color: #5c5447;
+		background: linear-gradient(180deg, #3a342b 0%, #2f2a23 100%);
+		color: #d6cec2;
+	}
+
+	html.oj-dark-mode .${ACTION_BUTTON_CLASS}:hover {
+		border-color: #7a705f;
+		background: linear-gradient(180deg, #463f35 0%, #383127 100%);
+		box-shadow: 0 1px 0 rgba(0, 0, 0, 0.24);
+	}
+
+	html.oj-dark-mode .${ACTION_BUTTON_CLASS}:active {
+		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+	}
+`;

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -1,5 +1,7 @@
 import { type GetItemOptions, storage } from '@wxt-dev/storage';
 
+export type StorageWatchCallback<T> = (newValue: T | null, oldValue: T | null) => void;
+
 const lStorage = {
 	getItem<TValue>(key: string, opts?: GetItemOptions<TValue>): Promise<TValue | null> {
 		return storage.getItem(`local:${key}`, opts);
@@ -7,8 +9,12 @@ const lStorage = {
 	setItem<T>(key: string, value: T | null): Promise<void> {
 		return storage.setItem(`local:${key}`, value);
 	},
+	// used for tests
 	clear(): Promise<void> {
 		return storage.clear('local');
+	},
+	watch<T>(key: string, cb: StorageWatchCallback<T>): () => void {
+		return storage.watch(`local:${key}`, cb);
 	},
 };
 

--- a/src/utils/muted-users.test.ts
+++ b/src/utils/muted-users.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import lStorage from '@/utils/local-storage.ts';
+import {
+	getMutedUsers,
+	isMutedUser,
+	MUTED_USERS_STORAGE_KEY,
+	setMutedUsers,
+	toggleMutedUser,
+} from '@/utils/muted-users.ts';
+
+describe('muted-users', () => {
+	beforeEach(async () => {
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, null);
+	});
+
+	describe('getMutedUsers', () => {
+		it('returns an empty list for missing or invalid stored values', async () => {
+			const cases = [
+				{ name: 'empty storage', stored: null },
+				{ name: 'plain string', stored: 'pg' },
+				{ name: 'object', stored: { username: 'pg' } },
+			] as const;
+
+			for (const { name, stored } of cases) {
+				await lStorage.setItem(MUTED_USERS_STORAGE_KEY, stored);
+
+				await expect(getMutedUsers(), name).resolves.toEqual([]);
+			}
+		});
+
+		it('normalizes stored muted users by trimming, removing empties, and deduplicating', async () => {
+			await lStorage.setItem(MUTED_USERS_STORAGE_KEY, [' alice ', 'bob', '', 'alice', '  ']);
+
+			await expect(getMutedUsers()).resolves.toEqual(['alice', 'bob']);
+		});
+	});
+
+	describe('setMutedUsers', () => {
+		it('deduplicates and trims muted users before storing them', async () => {
+			await expect(setMutedUsers([' alice ', 'bob', 'alice', ''])).resolves.toEqual([
+				'alice',
+				'bob',
+			]);
+			await expect(getMutedUsers()).resolves.toEqual(['alice', 'bob']);
+		});
+	});
+
+	describe('isMutedUser', () => {
+		it('reports whether a user is muted after normalization', async () => {
+			await setMutedUsers(['dang']);
+
+			await expect(isMutedUser('dang')).resolves.toBe(true);
+			await expect(isMutedUser(' dang ')).resolves.toBe(true);
+			await expect(isMutedUser('pg')).resolves.toBe(false);
+			await expect(isMutedUser('   ')).resolves.toBe(false);
+		});
+	});
+
+	describe('toggleMutedUser', () => {
+		it('toggles a user on and off', async () => {
+			await expect(toggleMutedUser('pg')).resolves.toBe(true);
+			await expect(getMutedUsers()).resolves.toEqual(['pg']);
+
+			await expect(toggleMutedUser('pg')).resolves.toBe(false);
+			await expect(getMutedUsers()).resolves.toEqual([]);
+		});
+
+		it('appends a new muted user without disturbing existing order', async () => {
+			await setMutedUsers(['pg', 'dang']);
+
+			await expect(toggleMutedUser('tptacek')).resolves.toBe(true);
+			await expect(getMutedUsers()).resolves.toEqual(['pg', 'dang', 'tptacek']);
+		});
+
+		it('rejects empty usernames when toggling', async () => {
+			await expect(toggleMutedUser('   ')).rejects.toThrow('Username is required.');
+		});
+	});
+});

--- a/src/utils/muted-users.ts
+++ b/src/utils/muted-users.ts
@@ -1,0 +1,60 @@
+import lStorage from '@/utils/local-storage.ts';
+
+export const MUTED_USERS_STORAGE_KEY = 'oj_muted_users';
+
+const normalizeUsername = (username: string): string => username.trim();
+
+const sanitizeMutedUsers = (usernames: readonly string[]): string[] => {
+	const deduped = new Set<string>();
+
+	for (const username of usernames) {
+		const normalized = normalizeUsername(username);
+		if (!normalized) {
+			continue;
+		}
+		deduped.add(normalized);
+	}
+
+	return Array.from(deduped);
+};
+
+export const getMutedUsers = async (): Promise<string[]> => {
+	const stored = await lStorage.getItem<string[]>(MUTED_USERS_STORAGE_KEY);
+	if (!Array.isArray(stored)) {
+		return [];
+	}
+
+	return sanitizeMutedUsers(stored);
+};
+
+export const setMutedUsers = async (usernames: readonly string[]): Promise<string[]> => {
+	const nextUsernames = sanitizeMutedUsers(usernames);
+	await lStorage.setItem(MUTED_USERS_STORAGE_KEY, nextUsernames);
+	return nextUsernames;
+};
+
+export const isMutedUser = async (username: string): Promise<boolean> => {
+	const normalized = normalizeUsername(username);
+	if (!normalized) {
+		return false;
+	}
+
+	const mutedUsers = await getMutedUsers();
+	return mutedUsers.includes(normalized);
+};
+
+export const toggleMutedUser = async (username: string): Promise<boolean> => {
+	const normalized = normalizeUsername(username);
+	if (!normalized) {
+		throw new Error('Username is required.');
+	}
+
+	const mutedUsers = await getMutedUsers();
+	const isMuted = mutedUsers.includes(normalized);
+	const nextUsernames = isMuted
+		? mutedUsers.filter((entry) => entry !== normalized)
+		: [...mutedUsers, normalized];
+
+	await setMutedUsers(nextUsernames);
+	return !isMuted;
+};


### PR DESCRIPTION
## Summary
- Add muted users functionality with local storage persistence
- User hover cards now include a mute/unmute toggle
- Muted comments are styled with muted colors in thread pages
- Muted users row added to user profile pages for easy management
- Follow button now inserts after muted marker when present

## Changes
- Extract action button styles to shared utility
- Add HNComment methods: getAuthor, setMuted, commentHead, commentText
- Add muted users utility with local storage persistence
- Add muted comments styling and sync for comment threads
- Add muted users row to user profile pages
- Fix follow button insertion order