### PR TITLE
fix: release runs independently on PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
     uses: ./.github/workflows/codeql.yml
 
   release:
-    needs: [test, test-latest, codeql]
     # Only run when a PR is closed (merged) on main
     if: >
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
Release job now runs independently without needing test/codeql jobs to complete.