### PR TITLE
fix: release checkout main on PR close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Setup Bun


### PR DESCRIPTION
Release job now explicitly checks out main to avoid issues when triggered by PR close.