### PR TITLE
fix(release): push detached head to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           git add package.json
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin main
+          git push origin HEAD:main
           git push origin "v${{ steps.bump.outputs.new_version }}"
 
       - name: Generate changelog


### PR DESCRIPTION
## Summary
- fix the release workflow version bump push step for detached HEAD checkouts
- change the refspec from `main` to `HEAD:main`
- keep tag push behavior unchanged

## Problem
The release job creates the version bump commit from a detached HEAD checkout. Pushing with `git push origin main` fails because there is no local `main` ref in that state.

## Fix
Use `git push origin HEAD:main` so the current detached commit is pushed to the remote `main` branch before pushing the release tag.

## Verification
- pre-commit `bun run check` passed
- pre-push `bun run build` passed
- pre-push `bun run test` passed