### PR TITLE
feat(ci): use gh commit for GitHub App signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,10 @@ jobs:
       - name: Commit version bump
         env:
           LEFTHOOK: 0
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add package.json
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+          gh commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           git tag "v${{ steps.bump.outputs.new_version }}"
           git push origin HEAD:main
           git push origin "v${{ steps.bump.outputs.new_version }}"


### PR DESCRIPTION
## Summary
- Use `gh commit` instead of `git commit` to ensure commits are signed via the GitHub API when using a GitHub App token

## Testing
- Build passes
- Tests pass