### PR TITLE
fix(ci): revert to git commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,9 @@ jobs:
       - name: Commit version bump
         env:
           LEFTHOOK: 0
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add package.json
-          gh commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           git tag "v${{ steps.bump.outputs.new_version }}"
           git push origin HEAD:main
           git push origin "v${{ steps.bump.outputs.new_version }}"


### PR DESCRIPTION
Revert  back to On branch fix/use-git-commit-in-release
Your branch is up to date with 'origin/fix/use-git-commit-in-release'.

nothing to commit, working tree clean since  does not exist.