### PR TITLE
chore(ci): skip codeql on release commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           LEFTHOOK: 0
         with:
-          message: "chore: bump version to ${{ steps.bump.outputs.new_version }}"
+          message: "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
           token: ${{ steps.app-token.outputs.token }}
           files: package.json
 


### PR DESCRIPTION
## Summary
- Skip CodeQL on release commit messages by adding `[skip ci]` to the commit message