### PR TITLE
fix(ci): skip codeql job on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: bun run ci
 
   codeql:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && !(github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary
- Skip codeql job when pushing directly to main branch