### PR TITLE
feat(popup): make logo and 'Orange Juice' text link to website

### DIFF
--- a/src/entrypoints/popup/App.css
+++ b/src/entrypoints/popup/App.css
@@ -74,6 +74,11 @@
 	color: var(--popup-muted);
 }
 
+.oj-popup__text a,
+.oj-popup__text a:visited {
+	color: var(--popup-accent);
+}
+
 .oj-popup__settings {
 	display: grid;
 	gap: 12px;

--- a/src/entrypoints/popup/popup-app.tsx
+++ b/src/entrypoints/popup/popup-app.tsx
@@ -169,12 +169,18 @@ const createPopupContent = (doc: Document): HTMLElement => {
 	const header = doc.createElement('div');
 	header.className = 'oj-popup__header';
 
+	const logoLink = doc.createElement('a');
+	logoLink.href = 'https://oj-hn.com';
+	logoLink.rel = 'noopener';
+	logoLink.target = '_blank';
+
 	const logo = doc.createElement('img');
 	logo.alt = 'Orange Juice logo';
 	logo.className = 'oj-popup__logo';
 	logo.height = 64;
 	logo.src = getLogoUrl();
 	logo.width = 64;
+	logoLink.append(logo);
 
 	const titleGroup = doc.createElement('div');
 
@@ -184,10 +190,16 @@ const createPopupContent = (doc: Document): HTMLElement => {
 
 	const text = doc.createElement('p');
 	text.className = 'oj-popup__text';
-	text.textContent = 'Control the Orange Juice.';
+	text.textContent = 'Control the ';
+	const link = doc.createElement('a');
+	link.href = 'https://oj-hn.com';
+	link.rel = 'noopener';
+	link.target = '_blank';
+	link.textContent = 'Orange Juice';
+	text.append(link, '.');
 
 	titleGroup.append(title, text);
-	header.append(logo, titleGroup);
+	header.append(logoLink, titleGroup);
 
 	const settingsList = doc.createElement('div');
 	settingsList.className = 'oj-popup__settings';


### PR DESCRIPTION
## Summary
- Make logo in popup clickable, linking to https://oj-hn.com
- Make "Orange Juice" text in the tagline a link to https://oj-hn.com
- Apply HN orange color to links even when visited