### PR TITLE
feat(comment): add collapse root keyboard command (C)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,6 @@
 			name="description"
 			content="Orange Juice - A browser extension that makes Hacker News sweeter with thoughtful improvements to the reading and posting experience."
 		>
-		<link rel="canonical" href="https://orangejuiceextension.github.io/">
 		<meta property="og:locale" content="en_US">
 		<meta property="og:type" content="website">
 		<meta property="og:site_name" content="Orange Juice">
@@ -45,9 +44,11 @@
 		>
 		<meta name="google-site-verification" content="CmxV6rHmyoN5YY4hFv4rROt6EBC_peWcItWWbfljyLo">
 		<title>Orange Juice - Make Hacker News Sweeter</title>
+		<link rel="canonical" href="https://oj-hn.com">
 		<link rel="icon" type="image/png" href="./assets/image-128.png">
 		<link rel="apple-touch-icon" href="./assets/image-128.png">
 		<link rel="stylesheet" href="./docs-theme.css?v=2026-02-09">
+		<link rel="sitemap" type="application/xml" href="./sitemap.xml">
 		<script src="./docs-theme.js?v=2026-02-09"></script>
 		<script type="application/ld+json">
 			{

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	<url>
+		<loc>https://oj-hn.com/</loc>
+		<changefreq>daily</changefreq>
+		<priority>1.0</priority>
+	</url>
+	<url>
+		<loc>https://oj-hn.com/privacy.html</loc>
+		<changefreq>monthly</changefreq>
+		<priority>0.8</priority>
+	</url>
+	<url>
+		<loc>https://oj-hn.com/terms.html</loc>
+		<changefreq>monthly</changefreq>
+		<priority>0.8</priority>
+	</url>
+</urlset>

--- a/src/components/comment/hn-comment.test.ts
+++ b/src/components/comment/hn-comment.test.ts
@@ -353,23 +353,8 @@ describe('HNComment', () => {
 		it('should click collapse link with [–]', () => {
 			const row = createCommentRow();
 			const toggle = doc.createElement('a');
-			toggle.classList.add('togg', 'clicky');
-			toggle.textContent = '[–]';
-			row.appendChild(toggle);
-			const clickSpy = vi.spyOn(toggle, 'click');
-			const comment = new HNComment(row);
-
-			const result = comment.collapseToggle();
-
-			expect(result).toBe(true);
-			expect(clickSpy).toHaveBeenCalled();
-		});
-
-		it('should click collapse link with [-]', () => {
-			const row = createCommentRow();
-			const toggle = doc.createElement('a');
 			toggle.classList.add('togg');
-			toggle.textContent = '[-]';
+			toggle.textContent = '[–]';
 			row.appendChild(toggle);
 			const clickSpy = vi.spyOn(toggle, 'click');
 			const comment = new HNComment(row);
@@ -452,6 +437,177 @@ describe('HNComment', () => {
 			row.appendChild(inner);
 
 			expect(HNComment.getCommentIdFromElement(inner)).toBe('comment-1');
+		});
+	});
+
+	describe('getCollapseRootLink', () => {
+		it('should return the collapse root link when present', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a href="user?id=test">test</a>
+						<a style="cursor: pointer;">[collapse root]</a>
+					</span>
+				</td>
+			`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getCollapseRootLink();
+
+			expect(link).toBeTruthy();
+			expect(link?.textContent).toBe('[collapse root]');
+		});
+
+		it('should return undefined when no collapse root link exists', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a href="user?id=test">test</a>
+					</span>
+				</td>
+			`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getCollapseRootLink();
+
+			expect(link).toBeUndefined();
+		});
+
+		it('should return undefined when comment head does not exist', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('comtr');
+			row.innerHTML = `<td class="default"></td>`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getCollapseRootLink();
+
+			expect(link).toBeUndefined();
+		});
+	});
+
+	describe('getRootCommentElement', () => {
+		it('should return the root comment element for a reply', () => {
+			const rootRow = doc.createElement('tr');
+			rootRow.classList.add('athing', 'comtr');
+			rootRow.innerHTML = `
+				<td class="default">
+					<span class="ind"><img src="s.gif" width="0"></span>
+				</td>
+			`;
+			const replyRow = doc.createElement('tr');
+			replyRow.classList.add('athing', 'comtr');
+			replyRow.innerHTML = `
+				<td class="default">
+					<span class="ind"><img src="s.gif" width="40"></span>
+				</td>
+			`;
+			doc.body.appendChild(rootRow);
+			doc.body.appendChild(replyRow);
+			const comment = new HNComment(replyRow);
+
+			const root = comment.getRootCommentElement();
+
+			expect(root).toBe(rootRow);
+		});
+
+		it('should return undefined when there is no previous sibling with indent 0', () => {
+			const replyRow = doc.createElement('tr');
+			replyRow.classList.add('athing', 'comtr');
+			replyRow.innerHTML = `
+				<td class="default">
+					<span class="ind"><img src="s.gif" width="40"></span>
+				</td>
+			`;
+			doc.body.appendChild(replyRow);
+			const comment = new HNComment(replyRow);
+
+			const root = comment.getRootCommentElement();
+
+			expect(root).toBeUndefined();
+		});
+
+		it('should return undefined for a root comment itself', () => {
+			const rootRow = doc.createElement('tr');
+			rootRow.classList.add('athing', 'comtr');
+			rootRow.innerHTML = `
+				<td class="default">
+					<span class="ind"><img src="s.gif" width="0"></span>
+				</td>
+			`;
+			doc.body.appendChild(rootRow);
+			const comment = new HNComment(rootRow);
+
+			const root = comment.getRootCommentElement();
+
+			expect(root).toBeUndefined();
+		});
+	});
+
+	describe('getExpandRootLink', () => {
+		it('should return the expand root link when comment is collapsed with [N more]', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('athing', 'comtr', 'coll');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="togg clicky" href="javascript:void(0)">[8 more]</a>
+					</span>
+					<div class="noshow">
+						<div class="commtext c00">hidden text</div>
+					</div>
+				</td>
+			`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getExpandRootLink();
+
+			expect(link).toBeTruthy();
+			expect(link?.textContent).toBe('[8 more]');
+		});
+
+		it('should return undefined when no [N more] link exists', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('athing', 'comtr');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a href="user?id=test">test</a>
+					</span>
+				</td>
+			`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getExpandRootLink();
+
+			expect(link).toBeUndefined();
+		});
+
+		it('should return the link for various N values', () => {
+			const row = doc.createElement('tr');
+			row.classList.add('athing', 'comtr', 'coll');
+			row.innerHTML = `
+				<td class="default">
+					<span class="comhead">
+						<a class="togg clicky" href="javascript:void(0)">[1 more]</a>
+					</span>
+				</td>
+			`;
+			doc.body.appendChild(row);
+			const comment = new HNComment(row);
+
+			const link = comment.getExpandRootLink();
+
+			expect(link).toBeTruthy();
+			expect(link?.textContent).toBe('[1 more]');
 		});
 	});
 });

--- a/src/components/comment/hn-comment.ts
+++ b/src/components/comment/hn-comment.ts
@@ -1,7 +1,8 @@
+import { dom } from '@/utils/dom.ts';
 import { parseReferenceLinks } from '@/utils/parse-reference-links.ts';
 
 const COMMENTS_REGEX = /\[\s*(\d+)\s*more\s*]/;
-const COLLAPSE_LABELS = new Set(['[-]', '[–]']);
+const COLLAPSE_LABEL_REGEX = /^\[–]$/;
 const VOTE_SELECTORS = {
 	UNVOTE_LINK: 'a[id^="un_"]',
 	UPVOTE_ARROW: 'div.votearrow[title="upvote"]',
@@ -193,13 +194,52 @@ export class HNComment {
 		const toggleLinks = this.commentRow.querySelectorAll<HTMLAnchorElement>('a.togg');
 		for (const el of toggleLinks) {
 			const trimmed = el.textContent?.trim() || '';
-			const isCollapsed = COMMENTS_REGEX.test(trimmed);
-			if (COLLAPSE_LABELS.has(trimmed) || isCollapsed) {
+			const isCollapsedToggle =
+				COLLAPSE_LABEL_REGEX.test(trimmed) || COMMENTS_REGEX.test(trimmed);
+			if (isCollapsedToggle) {
 				el.click();
 				return true;
 			}
 		}
 		return false;
+	}
+
+	getCollapseRootLink(): HTMLAnchorElement | undefined {
+		const comhead = this.commentHead;
+		if (!comhead) {
+			return undefined;
+		}
+		for (const link of comhead.querySelectorAll('a')) {
+			if (link.textContent === '[collapse root]') {
+				return link as HTMLAnchorElement;
+			}
+		}
+		return undefined;
+	}
+
+	getExpandRootLink(): HTMLAnchorElement | undefined {
+		const toggleLinks = this.commentRow.querySelectorAll<HTMLAnchorElement>('a.togg');
+		for (const el of toggleLinks) {
+			const trimmed = el.textContent?.trim() || '';
+			if (COMMENTS_REGEX.test(trimmed)) {
+				return el;
+			}
+		}
+		return undefined;
+	}
+
+	getRootCommentElement(): HTMLElement | undefined {
+		let rootRow: HTMLElement | null = null;
+		let currentRow = this.commentRow.previousElementSibling as HTMLElement | null;
+		while (currentRow) {
+			const indent = dom.getCommentIndentation(currentRow);
+			if (indent.width === 0) {
+				rootRow = currentRow;
+				break;
+			}
+			currentRow = currentRow.previousElementSibling as HTMLElement | null;
+		}
+		return rootRow ?? undefined;
 	}
 
 	getNextSiblingLink(): HTMLAnchorElement | undefined {

--- a/src/components/comment/keyboard-handlers.test.ts
+++ b/src/components/comment/keyboard-handlers.test.ts
@@ -754,9 +754,9 @@ describe('commentKeyboardHandlers', () => {
 			rootRow.appendChild(rootComhead);
 
 			await setup.commentData.activate(child);
-			const toggleClickSpy = vi.spyOn(rootToggle, 'click');
+			const toggleClickSpy = vi.spyOn(collapseRootLink, 'click');
 
-			await keyboardHandlers.collapseRoot(setup.commentData);
+			await keyboardHandlers.collapseExpandRoot(setup.commentData);
 
 			expect(toggleClickSpy).toHaveBeenCalled();
 			expect(setup.commentData.getActiveComment()?.id).toBe('comment-1');
@@ -770,7 +770,7 @@ describe('commentKeyboardHandlers', () => {
 			}
 			await setup.commentData.activate(first);
 
-			expect(() => keyboardHandlers.collapseRoot(setup.commentData)).not.toThrow();
+			expect(() => keyboardHandlers.collapseExpandRoot(setup.commentData)).not.toThrow();
 		});
 
 		it('should not click toggle when collapse root link text is different', async () => {
@@ -806,7 +806,7 @@ describe('commentKeyboardHandlers', () => {
 			await setup.commentData.activate(child);
 			const toggleClickSpy = vi.spyOn(rootToggle, 'click');
 
-			await keyboardHandlers.collapseRoot(setup.commentData);
+			await keyboardHandlers.collapseExpandRoot(setup.commentData);
 
 			expect(toggleClickSpy).not.toHaveBeenCalled();
 		});

--- a/src/components/comment/keyboard-handlers.test.ts
+++ b/src/components/comment/keyboard-handlers.test.ts
@@ -722,6 +722,96 @@ describe('commentKeyboardHandlers', () => {
 		});
 	});
 
+	describe('collapseRoot', () => {
+		it('should click root toggle and activate root when collapse root link exists', async () => {
+			const setup = createCommentData(doc, 2);
+
+			const rootRow = setup.rows[0];
+			const childRow = setup.rows[1];
+			const root = setup.commentData.first();
+			const child = setup.commentData.get('comment-2');
+
+			if (!(rootRow && childRow && root && child)) {
+				throw new Error('Expected items to exist');
+			}
+
+			addIndentation(doc, rootRow, 0);
+			addIndentation(doc, childRow, 1);
+
+			const childComhead = doc.createElement('span');
+			childComhead.classList.add('comhead');
+			const collapseRootLink = doc.createElement('a');
+			collapseRootLink.textContent = '[collapse root]';
+			childComhead.appendChild(collapseRootLink);
+			childRow.appendChild(childComhead);
+
+			const rootComhead = doc.createElement('span');
+			rootComhead.classList.add('comhead');
+			const rootToggle = doc.createElement('a');
+			rootToggle.classList.add('togg', 'clicky');
+			rootToggle.textContent = '[–]';
+			rootComhead.appendChild(rootToggle);
+			rootRow.appendChild(rootComhead);
+
+			await setup.commentData.activate(child);
+			const toggleClickSpy = vi.spyOn(rootToggle, 'click');
+
+			await keyboardHandlers.collapseRoot(setup.commentData);
+
+			expect(toggleClickSpy).toHaveBeenCalled();
+			expect(setup.commentData.getActiveComment()?.id).toBe('comment-1');
+		});
+
+		it('should not throw when no collapse root link exists', async () => {
+			const setup = createCommentData(doc, 1);
+			const first = setup.commentData.first();
+			if (!first) {
+				throw new Error('Expected item to exist');
+			}
+			await setup.commentData.activate(first);
+
+			expect(() => keyboardHandlers.collapseRoot(setup.commentData)).not.toThrow();
+		});
+
+		it('should not click toggle when collapse root link text is different', async () => {
+			const setup = createCommentData(doc, 2);
+
+			const rootRow = setup.rows[0];
+			const childRow = setup.rows[1];
+			const root = setup.commentData.first();
+			const child = setup.commentData.get('comment-2');
+
+			if (!(rootRow && childRow && root && child)) {
+				throw new Error('Expected items to exist');
+			}
+
+			addIndentation(doc, rootRow, 0);
+			addIndentation(doc, childRow, 1);
+
+			const childComhead = doc.createElement('span');
+			childComhead.classList.add('comhead');
+			const otherLink = doc.createElement('a');
+			otherLink.textContent = '[something else]';
+			childComhead.appendChild(otherLink);
+			childRow.appendChild(childComhead);
+
+			const rootComhead = doc.createElement('span');
+			rootComhead.classList.add('comhead');
+			const rootToggle = doc.createElement('a');
+			rootToggle.classList.add('togg', 'clicky');
+			rootToggle.textContent = '[–]';
+			rootComhead.appendChild(rootToggle);
+			rootRow.appendChild(rootComhead);
+
+			await setup.commentData.activate(child);
+			const toggleClickSpy = vi.spyOn(rootToggle, 'click');
+
+			await keyboardHandlers.collapseRoot(setup.commentData);
+
+			expect(toggleClickSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('navigateToThreadLink', () => {
 		it('should navigate to next link', async () => {
 			const setup = createCommentData(doc, 3);

--- a/src/components/comment/keyboard-handlers.ts
+++ b/src/components/comment/keyboard-handlers.ts
@@ -144,6 +144,35 @@ export class KeyboardHandlers {
 		commentData.collapseToggle();
 	}
 
+	async collapseExpandRoot(commentData: CommentData) {
+		const activeComment = commentData.getActiveComment();
+		if (!activeComment) {
+			return;
+		}
+
+		const collapseRootLink = activeComment.getCollapseRootLink();
+		if (collapseRootLink) {
+			const rootRow = activeComment.getRootCommentElement();
+			if (!rootRow) {
+				return;
+			}
+
+			const rootComment = commentData.getCommentFromElement(rootRow);
+			if (!rootComment) {
+				return;
+			}
+
+			collapseRootLink.click();
+			await commentData.deactivate();
+			await commentData.activate(rootComment);
+		} else {
+			const expandRootLink = activeComment.getExpandRootLink();
+			if (expandRootLink) {
+				expandRootLink.click();
+			}
+		}
+	}
+
 	async navigateToThreadLink(commentData: CommentData, linkText: 'next' | 'prev') {
 		const activeComment = commentData.getActiveComment();
 		if (!activeComment) {

--- a/src/components/comment/keyboard-navigation.test.ts
+++ b/src/components/comment/keyboard-navigation.test.ts
@@ -75,7 +75,7 @@ const createTestContext = (commentCount = 3): TestContext => {
 	vi.spyOn(KeyboardHandlers.prototype, 'upvote');
 	vi.spyOn(KeyboardHandlers.prototype, 'downvote');
 	vi.spyOn(KeyboardHandlers.prototype, 'collapseToggle');
-	vi.spyOn(KeyboardHandlers.prototype, 'collapseRoot');
+	vi.spyOn(KeyboardHandlers.prototype, 'collapseExpandRoot');
 	vi.spyOn(KeyboardHandlers.prototype, 'openReferenceLink');
 	vi.spyOn(KeyboardHandlers.prototype, 'activateElement');
 	vi.spyOn(KeyboardHandlers.prototype, 'checkActiveState');
@@ -278,14 +278,14 @@ describe('keyboardNavigation', () => {
 			invalidate();
 		});
 
-		it('C should call collapseRoot', async () => {
+		it('C should call collapseExpandRoot', async () => {
 			const { doc, comments, ctx, commentData, invalidate } = createTestContext();
 
 			await keyboardNavigation(ctx, doc, comments, commentData);
 			await activateFirstComment(commentData, comments);
 			dispatchKeydown(doc, 'C');
 
-			expect(KeyboardHandlers.prototype.collapseRoot).toHaveBeenCalled();
+			expect(KeyboardHandlers.prototype.collapseExpandRoot).toHaveBeenCalled();
 
 			invalidate();
 		});

--- a/src/components/comment/keyboard-navigation.test.ts
+++ b/src/components/comment/keyboard-navigation.test.ts
@@ -75,6 +75,7 @@ const createTestContext = (commentCount = 3): TestContext => {
 	vi.spyOn(KeyboardHandlers.prototype, 'upvote');
 	vi.spyOn(KeyboardHandlers.prototype, 'downvote');
 	vi.spyOn(KeyboardHandlers.prototype, 'collapseToggle');
+	vi.spyOn(KeyboardHandlers.prototype, 'collapseRoot');
 	vi.spyOn(KeyboardHandlers.prototype, 'openReferenceLink');
 	vi.spyOn(KeyboardHandlers.prototype, 'activateElement');
 	vi.spyOn(KeyboardHandlers.prototype, 'checkActiveState');
@@ -273,6 +274,18 @@ describe('keyboardNavigation', () => {
 			dispatchKeydown(doc, 'c');
 
 			expect(KeyboardHandlers.prototype.collapseToggle).toHaveBeenCalled();
+
+			invalidate();
+		});
+
+		it('C should call collapseRoot', async () => {
+			const { doc, comments, ctx, commentData, invalidate } = createTestContext();
+
+			await keyboardNavigation(ctx, doc, comments, commentData);
+			await activateFirstComment(commentData, comments);
+			dispatchKeydown(doc, 'C');
+
+			expect(KeyboardHandlers.prototype.collapseRoot).toHaveBeenCalled();
 
 			invalidate();
 		});

--- a/src/components/comment/keyboard-navigation.ts
+++ b/src/components/comment/keyboard-navigation.ts
@@ -217,6 +217,11 @@ export const keyboardNavigation = async (
 					keyboardHandlers.collapseToggle(commentData);
 				}
 				break;
+			case 'C':
+				if (!nonShiftCombo && commentData.getActiveComment()) {
+					await keyboardHandlers.collapseExpandRoot(commentData);
+				}
+				break;
 			case 't':
 				if (!combo) {
 					doc.body.scrollTo(0, 0);


### PR DESCRIPTION
## Summary
- Add 'C' keyboard shortcut to collapse/expand root comment from a reply
- When on a reply, pressing 'C' collapses the root comment and activates it
- When on a collapsed root (showing [N more]), pressing 'C' expands it

Fixes #45