### PR TITLE
fix(comment): include collapsed top-level threads in N/P navigation

### DIFF
--- a/.github/workflows/publish-chrome-release.yml
+++ b/.github/workflows/publish-chrome-release.yml
@@ -36,7 +36,8 @@ jobs:
           gh release download "${TAG}" \
             --pattern "${ASSET_NAME}" \
             --dir .
-
+          
+          echo "Asset: ${ASSET_NAME}"
           echo "asset_name=${ASSET_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Chrome Web Store
@@ -45,4 +46,4 @@ jobs:
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
-        run: bunx publish-extension --chrome-zip "${{ steps.release.outputs.asset_name }}"
+        run: bunx publish-browser-extension --chrome-zip "${{ steps.release.outputs.asset_name }}"

--- a/src/components/comment/comment-data.test.ts
+++ b/src/components/comment/comment-data.test.ts
@@ -182,6 +182,20 @@ describe('CommentData', () => {
 		expect(previous).toBeUndefined();
 	});
 
+	it('should include collapsed top-level comments when moving down at the same indent', () => {
+		const comments = createComments(doc, 5, { collapsedIds: [3] });
+		addIndentation(doc, comments[0].commentRow, 0);
+		addIndentation(doc, comments[1].commentRow, 1);
+		addIndentation(doc, comments[2].commentRow, 0);
+		addIndentation(doc, comments[3].commentRow, 1);
+		addIndentation(doc, comments[4].commentRow, 0);
+		const data = new CommentData(comments);
+
+		const next = data.getNextAtSameIndent(comments[0], 'down', false);
+
+		expect(next?.id).toBe('comment-3');
+	});
+
 	it('should proxy actions to active comment', async () => {
 		const comments = createComments(doc, 1);
 		const data = new CommentData(comments);

--- a/src/components/comment/keyboard-handlers.test.ts
+++ b/src/components/comment/keyboard-handlers.test.ts
@@ -942,6 +942,44 @@ describe('commentKeyboardHandlers', () => {
 	});
 
 	describe('moveAtSameIndent', () => {
+		it('should include collapsed top-level comments when moving down', async () => {
+			const setup = createCommentData(doc, 5, { collapsedIds: [3] });
+			const first = setup.commentData.first();
+			if (!first) {
+				throw new Error('Expected item to exist');
+			}
+
+			addIndentation(doc, setup.rows[0], 0);
+			addIndentation(doc, setup.rows[1], 1);
+			addIndentation(doc, setup.rows[2], 0);
+			addIndentation(doc, setup.rows[3], 1);
+			addIndentation(doc, setup.rows[4], 0);
+			await setup.commentData.activate(first);
+
+			await keyboardHandlers.moveAtSameIndent(setup.commentData, 'down');
+
+			expect(setup.commentData.getActiveComment()?.id).toBe('comment-3');
+		});
+
+		it('should include collapsed top-level comments when moving up', async () => {
+			const setup = createCommentData(doc, 5, { collapsedIds: [4] });
+			const fifth = setup.commentData.get('comment-5');
+			if (!fifth) {
+				throw new Error('Expected item to exist');
+			}
+
+			addIndentation(doc, setup.rows[0], 0);
+			addIndentation(doc, setup.rows[1], 0);
+			addIndentation(doc, setup.rows[2], 1);
+			addIndentation(doc, setup.rows[3], 0);
+			addIndentation(doc, setup.rows[4], 0);
+			await setup.commentData.activate(fifth);
+
+			await keyboardHandlers.moveAtSameIndent(setup.commentData, 'up');
+
+			expect(setup.commentData.getActiveComment()?.id).toBe('comment-4');
+		});
+
 		it('should move down to the next comment at the same indent', async () => {
 			const setup = createCommentData(doc, 6);
 			const first = setup.commentData.first();
@@ -1027,6 +1065,24 @@ describe('commentKeyboardHandlers', () => {
 
 			expect(setup.commentData.getActiveComment()?.id).toBe('comment-2');
 			expect(secondRow.classList.contains('oj_focused_comment')).toBe(true);
+		});
+
+		it('should move to the next visible top-level comment when no collapsed root exists', async () => {
+			const setup = createCommentData(doc, 4);
+			const first = setup.commentData.first();
+			if (!first) {
+				throw new Error('Expected item to exist');
+			}
+
+			addIndentation(doc, setup.rows[0], 0);
+			addIndentation(doc, setup.rows[1], 1);
+			addIndentation(doc, setup.rows[2], 0);
+			addIndentation(doc, setup.rows[3], 1);
+			await setup.commentData.activate(first);
+
+			await keyboardHandlers.moveAtSameIndent(setup.commentData, 'down');
+
+			expect(setup.commentData.getActiveComment()?.id).toBe('comment-3');
 		});
 	});
 

--- a/src/components/comment/keyboard-handlers.ts
+++ b/src/components/comment/keyboard-handlers.ts
@@ -208,7 +208,9 @@ export class KeyboardHandlers {
 		if (!activeComment) {
 			return;
 		}
-		const nextItem = commentData.getNextAtSameIndent(activeComment, direction);
+
+		const skipHidden = activeComment.getIndentLevel() !== 0;
+		const nextItem = commentData.getNextAtSameIndent(activeComment, direction, skipHidden);
 		if (!nextItem) {
 			activeComment.activate();
 			return;


### PR DESCRIPTION
## Summary
- keep N / P same-indent navigation for comment threads
- include collapsed top-level threads in that traversal instead of skipping past them
- add regression coverage for top-level collapsed-thread navigation

Fixes #44