### PR TITLE
fix(keyboard): disable shortcuts in editable fields

### DIFF
--- a/src/components/story/keyboard-navigation.test.ts
+++ b/src/components/story/keyboard-navigation.test.ts
@@ -91,6 +91,20 @@ const setLocationHref = (href: string) => {
 	});
 };
 
+const setActiveElement = (doc: Document, element: HTMLElement) => {
+	Object.defineProperty(doc, 'activeElement', {
+		configurable: true,
+		get: () => element,
+	});
+};
+
+const clearActiveElement = (doc: Document) => {
+	Object.defineProperty(doc, 'activeElement', {
+		configurable: true,
+		get: () => doc.body,
+	});
+};
+
 describe('story keyboard navigation', () => {
 	let doc: Document;
 	let ctx: ContentScriptContext;
@@ -325,6 +339,56 @@ describe('story keyboard navigation', () => {
 		await vi.waitFor(() => {
 			expect(storyData.getActiveStory()?.id).toBe('2');
 		});
+	});
+
+	it('should not trigger shortcuts while a text input is focused', async () => {
+		const storyData = createStoryData(doc);
+		const input = doc.createElement('input');
+		input.type = 'text';
+		doc.body.appendChild(input);
+		setActiveElement(doc, input);
+		const initialHref = window.location.href;
+
+		await keyboardNavigation(ctx, doc, storyData, { helpModalOpen: false });
+		doc.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+
+		expect(window.location.href).toBe(initialHref);
+
+		doc.body.removeChild(input);
+		clearActiveElement(doc);
+	});
+
+	it('should not trigger shortcuts while a textarea is focused', async () => {
+		const storyData = createStoryData(doc);
+		const textarea = doc.createElement('textarea');
+		doc.body.appendChild(textarea);
+		setActiveElement(doc, textarea);
+		const initialHref = window.location.href;
+
+		await keyboardNavigation(ctx, doc, storyData, { helpModalOpen: false });
+		doc.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+
+		expect(window.location.href).toBe(initialHref);
+
+		doc.body.removeChild(textarea);
+		clearActiveElement(doc);
+	});
+
+	it('should not trigger shortcuts while a contenteditable element is focused', async () => {
+		const storyData = createStoryData(doc);
+		const editable = doc.createElement('div');
+		editable.contentEditable = 'true';
+		doc.body.appendChild(editable);
+		setActiveElement(doc, editable);
+		const initialHref = window.location.href;
+
+		await keyboardNavigation(ctx, doc, storyData, { helpModalOpen: false });
+		doc.dispatchEvent(new KeyboardEvent('keydown', { key: 'm' }));
+
+		expect(window.location.href).toBe(initialHref);
+
+		doc.body.removeChild(editable);
+		clearActiveElement(doc);
 	});
 
 	it('should activate last story on pageshow when nav state is prev', async () => {

--- a/src/components/story/keyboard-navigation.ts
+++ b/src/components/story/keyboard-navigation.ts
@@ -117,6 +117,10 @@ export const keyboardNavigation = async (
 
 	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: shrug
 	const keydownHandler = (e: KeyboardEvent) => {
+		if (dom.isEditableField(doc.activeElement)) {
+			return;
+		}
+
 		if (navState?.helpModalOpen) {
 			if (e.key === 'Escape') {
 				return;

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -707,6 +707,41 @@ describe('dom', () => {
 		});
 	});
 
+	describe('isEditableField', () => {
+		it('should return true for text inputs', () => {
+			const input = document.createElement('input');
+			input.type = 'text';
+
+			expect(dom.isEditableField(input)).toBe(true);
+		});
+
+		it('should return false for non-text inputs', () => {
+			const input = document.createElement('input');
+			input.type = 'checkbox';
+
+			expect(dom.isEditableField(input)).toBe(false);
+		});
+
+		it('should return true for textareas', () => {
+			const textarea = document.createElement('textarea');
+
+			expect(dom.isEditableField(textarea)).toBe(true);
+		});
+
+		it('should return true for contenteditable elements', () => {
+			const div = document.createElement('div');
+			div.contentEditable = 'true';
+
+			expect(dom.isEditableField(div)).toBe(true);
+		});
+
+		it('should return false for non-editable elements', () => {
+			const div = document.createElement('div');
+
+			expect(dom.isEditableField(div)).toBe(false);
+		});
+	});
+
 	describe('removeClassRecursive', () => {
 		it('should remove single class from element', () => {
 			const div = document.createElement('div');

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -11,6 +11,18 @@ const TOP_BAR_DARK_TEXT_COLOR = '#111111';
 const TOP_BAR_LIGHT_TEXT_COLOR = '#f1efec';
 const SHORT_HEX_COLOR_PATTERN = /^#?([a-f0-9]{3})$/i;
 const HEX_COLOR_PATTERN = /^#?([a-f0-9]{6})$/i;
+const NON_TEXT_INPUT_TYPES = new Set([
+	'button',
+	'checkbox',
+	'color',
+	'file',
+	'hidden',
+	'image',
+	'radio',
+	'range',
+	'reset',
+	'submit',
+]);
 
 const createHiddenInput = (name: string, value: string) => {
 	const input = document.createElement('input');
@@ -273,6 +285,23 @@ function isComboKey(event: KeyboardEvent) {
 	return event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
 }
 
+function isEditableField(element?: Element | null) {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+
+	if (element instanceof HTMLTextAreaElement) {
+		return true;
+	}
+
+	if (element instanceof HTMLInputElement) {
+		const inputType = element.type.toLowerCase();
+		return !NON_TEXT_INPUT_TYPES.has(inputType);
+	}
+
+	return element.isContentEditable;
+}
+
 const createOptions = (start: number, end: number, step: number, selectedValue: number) => {
 	const options: HTMLOptionElement[] = [];
 	for (let i = start; step > 0 ? i <= end : i >= end; i += step) {
@@ -375,6 +404,7 @@ export const dom = {
 	getItemIdFromLocation,
 	isClickModified,
 	isComboKey,
+	isEditableField,
 	createOptions,
 	elementPosition,
 	elementInScrollView,


### PR DESCRIPTION
## Summary
- ignore story keyboard shortcuts while focus is in editable fields
- add a shared DOM helper for text-editable detection
- cover input, textarea, and contenteditable regressions

Fixes #59