### PR TITLE
fix(icon): reposition plus icon on follow-plus

### DIFF
--- a/public/icon/follow-plus.svg
+++ b/public/icon/follow-plus.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
   <circle cx="7.4" cy="5" r="2.5"/>
   <path d="M2.5 12.5c.7-2.1 2.5-3.2 5-3.2s4.2 1.1 4.9 3.2"/>
-  <path d="M12.8 5.9v4M10.8 7.9h4"/>
+  <path d="M13.25 5.9v4M11.25 7.9h4"/>
 </svg>


### PR DESCRIPTION
## Summary
- Reposition plus icon to stand equally away from head and body
- Move plus to the right, away from overlapping either element