### PR TITLE
fix(submit): widen submit form fields

### DIFF
--- a/src/components/submit/field-width.test.ts
+++ b/src/components/submit/field-width.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { widenFields } from './field-width.ts';
+
+describe('widenFields', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('sets submit text inputs and textareas to 80 columns', () => {
+		document.body.innerHTML = `
+			<form>
+				<input type="text" name="title" size="50">
+				<input type="text" name="url" size="50">
+				<textarea name="text" cols="48"></textarea>
+				<input type="submit" value="submit">
+			</form>
+		`;
+
+		widenFields(document);
+
+		const titleInput = document.querySelector<HTMLInputElement>('input[name="title"]');
+		const urlInput = document.querySelector<HTMLInputElement>('input[name="url"]');
+		const textArea = document.querySelector<HTMLTextAreaElement>('textarea[name="text"]');
+		expect(titleInput?.size).toBe(80);
+		expect(urlInput?.size).toBe(80);
+		expect(textArea?.getAttribute('cols')).toBe('80');
+	});
+});

--- a/src/components/submit/field-width.ts
+++ b/src/components/submit/field-width.ts
@@ -1,0 +1,17 @@
+const SUBMIT_FIELD_COLUMNS = 80;
+const SUBMIT_FIELD_SELECTOR = 'input[name="title"], input[name="url"], textarea';
+
+export const widenFields = (doc: Document): void => {
+	const submitFields = doc.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+		SUBMIT_FIELD_SELECTOR
+	);
+
+	for (const submitField of submitFields) {
+		if (submitField instanceof HTMLInputElement) {
+			submitField.size = SUBMIT_FIELD_COLUMNS;
+			continue;
+		}
+
+		submitField.cols = SUBMIT_FIELD_COLUMNS;
+	}
+};

--- a/src/components/submit/index.ts
+++ b/src/components/submit/index.ts
@@ -1,4 +1,5 @@
 import type { ContentScriptContext } from '#imports';
+import { widenFields } from '@/components/submit/field-width.ts';
 import { fetchTitle } from '@/components/submit/fetch-title.ts';
 import { prefill } from '@/components/submit/prefill.ts';
 import { remaining } from '@/components/submit/remaining.ts';
@@ -18,6 +19,7 @@ export const submit: ComponentFeature = {
 	runAt: 'document_end',
 	main(ctx: ContentScriptContext) {
 		return Promise.all([
+			Promise.resolve().then(() => widenFields(document)),
 			Promise.resolve().then(() => prefill(document)),
 			Promise.resolve().then(() => fetchTitle(ctx, document)),
 			Promise.resolve().then(() => remaining(ctx, document)),


### PR DESCRIPTION
## Summary
- widen the submit page title and url inputs to 80 columns
- widen submit textareas to 80 columns
- add a test covering the field width helper

## Testing
- bun run test src/components/submit/field-width.test.ts
- bun run check
- bun run compile