### PR TITLE
fix(comment): add scroll-to-top shortcut

### DIFF
--- a/src/components/comment/keyboard-handlers.test.ts
+++ b/src/components/comment/keyboard-handlers.test.ts
@@ -63,6 +63,35 @@ describe('commentKeyboardHandlers', () => {
 		vi.spyOn(lStorage, 'setItem').mockResolvedValue();
 	});
 
+	describe('scrollActiveCommentToTop', () => {
+		it('should scroll the active comment into view at the top', async () => {
+			const setup = createCommentData(doc, 2);
+			const first = setup.commentData.first();
+			if (!first) {
+				throw new Error('Expected item to exist');
+			}
+			await setup.commentData.activate(first);
+			const scrollSpy = vi
+				.spyOn(HTMLElement.prototype, 'scrollIntoView')
+				.mockImplementation(noop);
+
+			keyboardHandlers.scrollActiveCommentToTop(setup.commentData);
+
+			expect(scrollSpy).toHaveBeenCalledWith(true);
+		});
+
+		it('should do nothing when no comment is active', () => {
+			const setup = createCommentData(doc, 2);
+			const scrollSpy = vi
+				.spyOn(HTMLElement.prototype, 'scrollIntoView')
+				.mockImplementation(noop);
+
+			keyboardHandlers.scrollActiveCommentToTop(setup.commentData);
+
+			expect(scrollSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	it('should store and load active comment id for the current item', async () => {
 		const setup = createCommentData(doc, 1);
 		vi.spyOn(dom, 'getItemIdFromLocation').mockReturnValue('123');

--- a/src/components/comment/keyboard-handlers.ts
+++ b/src/components/comment/keyboard-handlers.ts
@@ -144,6 +144,15 @@ export class KeyboardHandlers {
 		commentData.collapseToggle();
 	}
 
+	scrollActiveCommentToTop(commentData: CommentData) {
+		const activeComment = commentData.getActiveComment();
+		if (!activeComment) {
+			return;
+		}
+
+		activeComment.commentRow.scrollIntoView(true);
+	}
+
 	async collapseExpandRoot(commentData: CommentData) {
 		const activeComment = commentData.getActiveComment();
 		if (!activeComment) {

--- a/src/components/comment/keyboard-navigation.test.ts
+++ b/src/components/comment/keyboard-navigation.test.ts
@@ -76,6 +76,7 @@ const createTestContext = (commentCount = 3): TestContext => {
 	vi.spyOn(KeyboardHandlers.prototype, 'downvote');
 	vi.spyOn(KeyboardHandlers.prototype, 'collapseToggle');
 	vi.spyOn(KeyboardHandlers.prototype, 'collapseExpandRoot');
+	vi.spyOn(KeyboardHandlers.prototype, 'scrollActiveCommentToTop');
 	vi.spyOn(KeyboardHandlers.prototype, 'openReferenceLink');
 	vi.spyOn(KeyboardHandlers.prototype, 'activateElement');
 	vi.spyOn(KeyboardHandlers.prototype, 'checkActiveState');
@@ -290,6 +291,18 @@ describe('keyboardNavigation', () => {
 			invalidate();
 		});
 
+		it('z should scroll the active comment to the top', async () => {
+			const { doc, comments, ctx, commentData, invalidate } = createTestContext();
+
+			await keyboardNavigation(ctx, doc, comments, commentData);
+			await activateFirstComment(commentData, comments);
+			dispatchKeydown(doc, 'z');
+
+			expect(KeyboardHandlers.prototype.scrollActiveCommentToTop).toHaveBeenCalled();
+
+			invalidate();
+		});
+
 		it('j should deactivate the previously active comment when moving down', async () => {
 			const { doc, comments, ctx, commentData, invalidate } = createTestContext();
 			const firstComment = getComment(comments, 0);
@@ -446,6 +459,7 @@ describe('keyboardNavigation', () => {
 			{ key: 'u', handler: 'upvote' },
 			{ key: 'd', handler: 'downvote' },
 			{ key: 'c', handler: 'collapseToggle' },
+			{ key: 'z', handler: 'scrollActiveCommentToTop' },
 			{ key: '0', handler: 'openReferenceLink' },
 		];
 
@@ -479,6 +493,7 @@ describe('keyboardNavigation', () => {
 			{ key: 'u', handler: 'upvote' },
 			{ key: 'd', handler: 'downvote' },
 			{ key: 'c', handler: 'collapseToggle' },
+			{ key: 'z', handler: 'scrollActiveCommentToTop' },
 		];
 
 		for (const { key, handler } of comboKeyTests) {

--- a/src/components/comment/keyboard-navigation.ts
+++ b/src/components/comment/keyboard-navigation.ts
@@ -222,6 +222,11 @@ export const keyboardNavigation = async (
 					await keyboardHandlers.collapseExpandRoot(commentData);
 				}
 				break;
+			case 'z':
+				if (!combo && commentData.getActiveComment()) {
+					keyboardHandlers.scrollActiveCommentToTop(commentData);
+				}
+				break;
 			case 't':
 				if (!combo) {
 					doc.body.scrollTo(0, 0);

--- a/src/components/common/keyboard-shortcuts-help.test.ts
+++ b/src/components/common/keyboard-shortcuts-help.test.ts
@@ -27,6 +27,13 @@ describe('keyboard shortcuts help', () => {
 		expect(text).toContain('n');
 	});
 
+	it('should include the comment scroll-to-top shortcut', () => {
+		const text = help.textContent ?? '';
+
+		expect(text).toContain('z');
+		expect(text).toContain('Scroll selected comment to top of window');
+	});
+
 	it('should include website and github links', () => {
 		const links = help.querySelectorAll('a');
 		const hrefs = new Set<string>();

--- a/src/components/common/keyboard-shortcuts-help.tsx
+++ b/src/components/common/keyboard-shortcuts-help.tsx
@@ -14,6 +14,7 @@ const SHORTCUTS_COMMENTS = [
 	{ key: 'f', description: 'Favorite selected comment' },
 	{ key: 'X', description: 'Flag selected comment' },
 	{ key: '0-9', description: 'Open reference link by number' },
+	{ key: 'z', description: 'Scroll selected comment to top of window' },
 	{ key: 't', description: 'Scroll to top of page' },
 	{ key: 'b', description: 'Go back (if paginated)' },
 	{ key: 'esc', description: 'Unfocus comment or close reply box' },


### PR DESCRIPTION
## Summary
- add a z comment shortcut to scroll the active comment to the top of the viewport
- document the shortcut in the keyboard help modal
- add handler and shortcut coverage tests

Fixes #65