### PR TITLE
fix: prevent flag/favorite cross-toggle state

### DIFF
--- a/src/components/common/activity-buttons.test.ts
+++ b/src/components/common/activity-buttons.test.ts
@@ -9,6 +9,35 @@ vi.mock('@/utils/dom', () => ({
 	dom: {
 		getAuthToken: vi.fn(),
 		toggleActivityState: vi.fn(),
+		findLinkByPathnameAndQueryParam: (
+			root: ParentNode,
+			selector: string,
+			pathname: string,
+			param: string,
+			value?: string,
+			baseUrl = window.location.origin
+		) => {
+			const candidates = root.querySelectorAll<HTMLAnchorElement>(selector);
+			for (const candidate of candidates) {
+				const href = candidate.getAttribute('href');
+				if (!href) {
+					continue;
+				}
+				const url = new URL(href, baseUrl);
+				if (url.pathname !== pathname) {
+					continue;
+				}
+				const paramValue = url.searchParams.get(param);
+				if (paramValue && (value === undefined || paramValue === value)) {
+					return candidate;
+				}
+			}
+			return;
+		},
+		getHrefQueryParam: (href: string, param: string, baseUrl = window.location.origin) => {
+			const url = new URL(href, baseUrl);
+			return url.searchParams.get(param) ?? undefined;
+		},
 	},
 }));
 
@@ -93,6 +122,22 @@ describe('activity-buttons', () => {
 
 				expect(result.element).toBe(link);
 				expect(result.id).toBe('11111');
+			});
+
+			it('should extract id when the item id param is not first', () => {
+				const nav = doc.createElement('div');
+				const link = doc.createElement('a');
+				link.href = 'item?foo=bar&id=22222';
+				nav.appendChild(link);
+
+				const extractor = idExtractors.get('/jobs');
+				if (!extractor) {
+					throw new Error('missing');
+				}
+				const result = extractor(nav);
+
+				expect(result.element).toBe(link);
+				expect(result.id).toBe('22222');
 			});
 
 			it('should return null when no item link exists', () => {
@@ -588,6 +633,12 @@ describe('activity-buttons', () => {
 					createNav: createComhead,
 					config: flagConfig,
 					expectedType: ActivityId.FlagsComments,
+				},
+				{
+					name: 'flag in subtext',
+					createNav: createSubtext,
+					config: flagConfig,
+					expectedType: ActivityId.FlagsSubmissions,
 				},
 			];
 

--- a/src/components/common/activity-buttons.ts
+++ b/src/components/common/activity-buttons.ts
@@ -3,7 +3,6 @@ import { DAYS_30 } from '@/utils/constants.ts';
 import { dom } from '@/utils/dom.ts';
 
 const unvPrefixPattern = /^unv_/;
-const itemIdPattern = /[?&]id=(\d+)/;
 const labelSeparatorPattern = /[\s-]+/g;
 
 export const idExtractors = new Map<
@@ -20,8 +19,24 @@ export const idExtractors = new Map<
 	[
 		'/jobs',
 		(nav) => {
-			const element = nav.querySelector<HTMLAnchorElement>('a[href*="item?id="]');
-			return { element, id: element?.href.match(itemIdPattern)?.[1] };
+			const link = dom.findLinkByPathnameAndQueryParam(
+				nav,
+				'a',
+				'/item',
+				'id',
+				undefined,
+				window.location.origin
+			);
+			if (link) {
+				const href = link.getAttribute('href');
+				return {
+					element: link,
+					id: href
+						? dom.getHrefQueryParam(href, 'id', window.location.origin)
+						: undefined,
+				};
+			}
+			return { element: null, id: undefined };
 		},
 	],
 ]);
@@ -68,8 +83,9 @@ const activityTypeFromClassList = (
 	if (classList.contains('subtext')) {
 		switch (componentType) {
 			case 'favorite':
-			case 'flag':
 				return ActivityId.FavoriteSubmissions;
+			case 'flag':
+				return ActivityId.FlagsSubmissions;
 			case 'vote':
 				return ActivityId.VotesSubmissions;
 			default:

--- a/src/components/user/muted-users-row.test.ts
+++ b/src/components/user/muted-users-row.test.ts
@@ -126,6 +126,30 @@ describe('mutedUsersRow', () => {
 		expect(document.querySelector('.oj-muted-users-row')?.textContent).toContain('alice');
 	});
 
+	it('supports current user links with reordered query params', async () => {
+		window.history.pushState({}, '', '/user?id=latchkey');
+		document.body.innerHTML = `
+			<span class="pagetop">
+				<a href="user?foo=bar&id=latchkey">latchkey</a>
+			</span>
+			<form action="xuser" method="post">
+				<table>
+					<tbody>
+						<tr>
+							<td>user:</td>
+							<td><a href="user?id=latchkey" class="hnuser">latchkey</a></td>
+						</tr>
+					</tbody>
+				</table>
+			</form>
+		`;
+		await lStorage.setItem(MUTED_USERS_STORAGE_KEY, ['alice']);
+
+		await mutedUsersRow(mockCtx, document);
+
+		expect(document.querySelector('.oj-muted-users-row')?.textContent).toContain('alice');
+	});
+
 	it('shows none when no users are muted', async () => {
 		window.history.pushState({}, '', '/user?id=latchkey');
 		renderProfileForm();

--- a/src/components/user/muted-users-row.ts
+++ b/src/components/user/muted-users-row.ts
@@ -1,5 +1,6 @@
 import type { ContentScriptContext } from '#imports';
 import { ACTION_BUTTON_CLASS, getActionButtonStyle } from '@/utils/action-button.ts';
+import { dom } from '@/utils/dom.ts';
 import lStorage from '@/utils/local-storage.ts';
 import {
 	getMutedUsers,
@@ -59,8 +60,15 @@ const removeExistingRow = (tableBody: HTMLTableSectionElement): void => {
 };
 
 const getCurrentUsername = (doc: Document): string | undefined =>
-	doc
-		.querySelector<HTMLAnchorElement>('span.pagetop a[href*="user?id="]')
+	dom
+		.findLinkByPathnameAndQueryParam(
+			doc,
+			'span.pagetop a',
+			'/user',
+			'id',
+			undefined,
+			window.location.origin
+		)
 		?.textContent?.split(' ')[0] || undefined;
 
 const getProfileUsername = (tableBody: HTMLTableSectionElement): string | undefined => {

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -44,6 +44,18 @@ describe('dom', () => {
 			expect(username).toBe('testuser');
 		});
 
+		it('should return username when the user id param is not first', async () => {
+			document.body.innerHTML = `
+				<span class="pagetop">
+					<a href="user?foo=bar&id=testuser" id="me">testuser ▾</a>
+				</span>
+			`;
+
+			const username = await dom.getUsername(document.body);
+
+			expect(username).toBe('testuser');
+		});
+
 		it('should return username without up arrow', async () => {
 			document.body.innerHTML = `
 				<span class="pagetop">
@@ -320,6 +332,56 @@ describe('dom', () => {
 			const token = await dom.getAuthToken('123', ActivityId.FavoriteSubmissions);
 
 			expect(token).toBeUndefined();
+			getPageDomSpy.mockRestore();
+		});
+
+		it('should prefer a matching comment action link over earlier item links', async () => {
+			const itemDiv = document.createElement('body');
+			itemDiv.innerHTML = `
+				<table class="fatitem">
+					<tr>
+						<td class="subtext">
+							<a href="fave?foo=bar&id=100&auth=story-auth">favorite</a>
+							<a href="flag?foo=bar&id=100&auth=story-flag-auth">flag</a>
+						</td>
+					</tr>
+				</table>
+				<tr class="athing comtr" id="200">
+					<td class="default">
+						<span class="comhead">
+							<a href="fave?foo=bar&id=200&auth=comment-auth">favorite</a>
+							<a href="flag?foo=bar&id=200&auth=comment-flag-auth">flag</a>
+						</span>
+					</td>
+				</tr>
+			`;
+			const getPageDomSpy = vi.spyOn(dom, 'getPageDom').mockResolvedValue(itemDiv);
+
+			const favoriteToken = await dom.getAuthToken('200', ActivityId.FavoriteComments);
+			const flagToken = await dom.getAuthToken('200', ActivityId.FlagsComments);
+
+			expect(favoriteToken).toBe('comment-auth');
+			expect(flagToken).toBe('comment-flag-auth');
+			getPageDomSpy.mockRestore();
+		});
+
+		it('should fall back to a matching hide link with reordered params', async () => {
+			const itemDiv = document.createElement('body');
+			itemDiv.innerHTML = `
+				<table class="fatitem">
+					<tr>
+						<td class="subtext">
+							<a href="hide?foo=bar&id=100&auth=story-hide-auth">hide</a>
+							<a href="hide?foo=bar&id=200&auth=comment-hide-auth">hide</a>
+						</td>
+					</tr>
+				</table>
+			`;
+			const getPageDomSpy = vi.spyOn(dom, 'getPageDom').mockResolvedValue(itemDiv);
+
+			const token = await dom.getAuthToken('200', ActivityId.FavoriteSubmissions);
+
+			expect(token).toBe('comment-hide-auth');
 			getPageDomSpy.mockRestore();
 		});
 	});

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -64,6 +64,47 @@ const fetchHmacFromPage = async (url: string): Promise<string> => {
 };
 
 const authMatchPattern = /auth=([^&]+)/;
+const getHrefQueryParam = (
+	href: string,
+	param: string,
+	baseUrl = paths.base
+): string | undefined => {
+	const url = new URL(href, baseUrl);
+	return url.searchParams.get(param) ?? undefined;
+};
+
+const findLinkByPathnameAndQueryParam = (
+	root: ParentNode,
+	selector: string,
+	pathname: string,
+	param: string,
+	value?: string,
+	baseUrl = paths.base
+): HTMLAnchorElement | undefined => {
+	const candidates = root.querySelectorAll<HTMLAnchorElement>(selector);
+
+	for (const candidate of candidates) {
+		const href = candidate.getAttribute('href');
+		if (!href) {
+			continue;
+		}
+
+		const url = new URL(href, baseUrl);
+		if (url.pathname !== pathname) {
+			continue;
+		}
+
+		const paramValue = url.searchParams.get(param);
+		if (paramValue && (value === undefined || paramValue === value)) {
+			return candidate;
+		}
+	}
+
+	return;
+};
+
+const findUserLink = (root: ParentNode): HTMLAnchorElement | undefined =>
+	findLinkByPathnameAndQueryParam(root, 'span.pagetop a', '/user', 'id');
 
 const getAuthToken = async (
 	commentId: string,
@@ -85,11 +126,23 @@ const getAuthToken = async (
 	token = hmacInput?.value;
 
 	if (!token) {
-		let actionLink = itemDiv.querySelector<HTMLAnchorElement>(`a[href*="${actionName}?id="]`);
+		let actionLink = findLinkByPathnameAndQueryParam(
+			itemDiv,
+			`a[href*="${actionName}?"]`,
+			`/${actionName}`,
+			'id',
+			commentId
+		);
 		if (!actionLink) {
 			// fall back to looking at the hide link. a job item only has that.
 			// ie: https://news.ycombinator.com/item?id=46840801
-			actionLink = itemDiv.querySelector<HTMLAnchorElement>(`a[href*="hide?id="]`);
+			actionLink = findLinkByPathnameAndQueryParam(
+				itemDiv,
+				'a[href*="hide?"]',
+				'/hide',
+				'id',
+				commentId
+			);
 		}
 		token = actionLink?.href.match(authMatchPattern)?.[1];
 	}
@@ -107,7 +160,7 @@ const setStoredUsername = async (username: string): Promise<void> => {
 };
 
 const getUsernameFromPage = (doc: HTMLElement): string | undefined => {
-	const userLink = doc.querySelector<HTMLAnchorElement>('span.pagetop a[href*="user?id="]');
+	const userLink = findUserLink(doc);
 	const username = userLink?.textContent.split(' ')[0];
 	return username || undefined;
 };
@@ -394,8 +447,10 @@ export const dom = {
 	getHiddenInputValue,
 	getPageDom,
 	fetchHmacFromPage,
+	getHrefQueryParam,
 	getUsername,
 	getItemAuthor,
+	findLinkByPathnameAndQueryParam,
 	ensureTopBarReadableText,
 	getItemIdFromLocation,
 	isClickModified,


### PR DESCRIPTION
## Summary
- fix incorrect flag activity mapping on item-page subtext actions
- make href/query matching order-independent for auth token, user, and jobs item lookups
- add regressions for reordered query params and comment-vs-story auth selection

## Testing
- bun run test
- bun run check
- bun run compile