### PR TITLE
fix(comment): avoid refocusing active comment

### DIFF
--- a/src/components/comment/comment-data.test.ts
+++ b/src/components/comment/comment-data.test.ts
@@ -54,6 +54,26 @@ describe('CommentData', () => {
 		expect(data.getActiveComment()).toBeUndefined();
 	});
 
+	it('should not deactivate and reactivate an already active comment', async () => {
+		const comments = createComments(doc, 1);
+		const data = new CommentData(comments);
+		const activateSpy = vi.spyOn(comments[0], 'activate');
+		const deactivateSpy = vi.spyOn(comments[0], 'deactivate');
+		const storeSpy = vi.spyOn(data, 'storeActiveCommentId');
+
+		await data.activate(comments[0]);
+		activateSpy.mockClear();
+		deactivateSpy.mockClear();
+		storeSpy.mockClear();
+
+		await data.activate(comments[0]);
+
+		expect(data.getActiveComment()).toBe(comments[0]);
+		expect(activateSpy).not.toHaveBeenCalled();
+		expect(deactivateSpy).not.toHaveBeenCalled();
+		expect(storeSpy).not.toHaveBeenCalled();
+	});
+
 	it('should skip hidden comments when getting next', () => {
 		const comments = createComments(doc, 3, { collapsedIds: [2] });
 		const data = new CommentData(comments);

--- a/src/components/comment/comment-data.ts
+++ b/src/components/comment/comment-data.ts
@@ -35,6 +35,9 @@ export class CommentData {
 	}
 
 	async activate(comment: HNComment): Promise<void> {
+		if (this.activeComment === comment) {
+			return;
+		}
 		await this.deactivate();
 		this.activeComment = comment;
 		comment.activate();

--- a/src/components/comment/keyboard-navigation.test.ts
+++ b/src/components/comment/keyboard-navigation.test.ts
@@ -655,6 +655,31 @@ describe('keyboardNavigation', () => {
 
 			invalidate();
 		});
+
+		it('should not redraw focus when clicking an already active comment again', async () => {
+			const { doc, comments, ctx, commentData, invalidate } = createTestContext();
+			const comment = getComment(comments, 0);
+
+			await keyboardNavigation(ctx, doc, comments, commentData);
+			await activateFirstComment(commentData, comments);
+
+			const activeComment = commentData.getActiveComment();
+			if (!activeComment) {
+				throw new Error('Expected active comment to exist');
+			}
+
+			const activateSpy = vi.spyOn(activeComment, 'activate');
+			const deactivateSpy = vi.spyOn(activeComment, 'deactivate');
+
+			dispatchClick(comment, comment);
+			await Promise.resolve();
+
+			expect(commentData.getActiveComment()).toBe(activeComment);
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(deactivateSpy).not.toHaveBeenCalled();
+
+			invalidate();
+		});
 	});
 
 	describe('document click handler', () => {


### PR DESCRIPTION
## Summary
- avoid deactivating and reactivating a comment when it is already active
- add coverage for repeated activation of the same comment
- add a click-path regression test for repeated active-comment clicks

## Testing
- bun run test src/components/comment/comment-data.test.ts src/components/comment/keyboard-navigation.test.ts
- bun run check
- bun run compile