### PR TITLE
fix(docs): align site metadata and add 404 page

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="theme-color" content="#ff6600">
+		<meta
+			name="description"
+			content="Orange Juice page not found. Head back to the homepage, install links, or project docs."
+		>
+		<meta name="robots" content="noindex">
+		<title>404 - Page Not Found - Orange Juice</title>
+		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-27">
+		<script src="./docs-theme.js?v=2026-02-09"></script>
+	</head>
+	<body class="oj-docs-page">
+		<div class="oj-docs-topbar">
+			<nav class="oj-docs-nav" aria-label="Docs navigation">
+				<a class="oj-docs-nav__link" href="./index.html">Home</a>
+				<a class="oj-docs-nav__link" href="./privacy.html">Privacy</a>
+				<a class="oj-docs-nav__link" href="./terms.html">Terms</a>
+				<a
+					class="oj-docs-nav__link oj-docs-nav__link--github"
+					href="https://github.com/OrangeJuiceExtension/OrangeJuice"
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label="Open GitHub repository in a new tab"
+				>
+					<svg
+						class="oj-docs-github-icon"
+						viewBox="0 0 16 16"
+						aria-hidden="true"
+						focusable="false"
+					>
+						<path
+							d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.39v-1.36c-2.23.48-2.7-.95-2.7-.95-.36-.92-.9-1.16-.9-1.16-.73-.5.06-.49.06-.49.81.06 1.24.84 1.24.84.71 1.22 1.88.87 2.34.66.07-.53.28-.88.5-1.08-1.78-.2-3.64-.89-3.64-3.95 0-.87.3-1.58.82-2.14-.08-.2-.36-1.01.08-2.1 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.09.16 1.9.08 2.1.51.56.82 1.27.82 2.14 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.47v2.17c0 .22.14.47.55.39A8 8 0 0 0 8 0Z"
+						/>
+					</svg>
+					<span>GitHub</span>
+				</a>
+			</nav>
+			<button
+				type="button"
+				class="oj-docs-theme-toggle"
+				aria-label="Toggle dark mode"
+			></button>
+		</div>
+		<div class="container">
+			<header>
+				<section class="error-page" aria-labelledby="error-title">
+					<div class="error-card" aria-hidden="true">
+						<img
+							class="logo-banner logo-banner--light"
+							src="./assets/og-card-1200x630.png"
+							alt=""
+							width="1200"
+							height="630"
+						>
+						<img
+							class="logo-banner logo-banner--dark"
+							src="./assets/og-card-dark-1200x630.png"
+							alt=""
+							width="1200"
+							height="630"
+						>
+						<p>Orange Juice still exists. Only this URL does not.</p>
+					</div>
+					<div class="error-copy">
+						<p class="error-code">Error 404</p>
+						<h1 class="error-title" id="error-title">
+							This page fell off the front page.
+						</h1>
+						<p class="error-summary">
+							The URL does not point to a published Orange Juice page. Head back to
+							the homepage and continue from there.
+						</p>
+						<div class="error-actions">
+							<a class="btn btn-primary" href="./index.html">Back to Home</a>
+						</div>
+					</div>
+				</section>
+			</header>
+			<footer>
+				<div class="footer-links">
+					<a
+						href="https://github.com/OrangeJuiceExtension/OrangeJuice"
+						target="_blank"
+						rel="noopener noreferrer"
+						>GitHub</a
+					>
+					<a href="./privacy.html" rel="noopener noreferrer">Privacy Policy</a>
+					<a href="./terms.html" rel="noopener noreferrer">Terms of Service</a>
+					<a
+						href="https://github.com/OrangeJuiceExtension/OrangeJuice/issues"
+						target="_blank"
+						rel="noopener noreferrer"
+						>Report an Issue</a
+					>
+				</div>
+				<p class="footer-note">
+					&copy; <span class="oj-docs-copyright-year"></span> Orange Juice Extension. All
+					rights reserved.
+				</p>
+			</footer>
+		</div>
+	</body>
+</html>

--- a/docs/docs-theme.css
+++ b/docs/docs-theme.css
@@ -262,6 +262,125 @@ html.oj-dark-mode .logo-banner--dark {
 	color: var(--text-light);
 }
 
+.error-page {
+	display: flex;
+	flex-direction: column;
+	gap: 2.25rem;
+	align-items: center;
+	padding: 2.5rem;
+	margin: 0 auto;
+	background:
+		radial-gradient(
+			circle at 15% 10%,
+			rgba(255, 102, 0, 0.18) 0,
+			transparent 35%
+		),
+		linear-gradient(135deg, var(--bg-alt) 0%, var(--bg) 100%);
+	border: 1px solid var(--border);
+	border-radius: 24px;
+	box-shadow: 0 24px 56px var(--shadow);
+}
+
+.error-copy {
+	width: 100%;
+	max-width: 42rem;
+	text-align: center;
+}
+
+.error-code {
+	display: inline-flex;
+	padding: 0.35rem 0.9rem;
+	margin-bottom: 1rem;
+	font-size: 0.82rem;
+	font-weight: 800;
+	color: var(--primary-dark);
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+	background: rgba(255, 102, 0, 0.12);
+	border: 1px solid rgba(255, 102, 0, 0.2);
+	border-radius: 999px;
+}
+
+.error-title {
+	margin: 0 0 1rem;
+	font-size: clamp(2.5rem, 7vw, 4.75rem);
+	line-height: 0.96;
+	color: var(--text);
+	text-wrap: balance;
+}
+
+.error-summary {
+	max-width: 34rem;
+	margin: 0 auto 1.5rem;
+	font-size: 1.1rem;
+	color: var(--text-light);
+}
+
+.error-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.9rem;
+	justify-content: center;
+}
+
+.error-card {
+	position: relative;
+	width: 100%;
+	max-width: 760px;
+	padding: 1.4rem;
+	overflow: hidden;
+	background:
+		linear-gradient(
+			180deg,
+			rgba(255, 255, 255, 0.26),
+			rgba(255, 255, 255, 0.06)
+		),
+		linear-gradient(135deg, rgba(255, 102, 0, 0.14), transparent 60%);
+	border: 1px solid rgba(255, 102, 0, 0.2);
+	border-radius: 20px;
+	box-shadow: 0 20px 40px rgba(31, 18, 8, 0.12);
+}
+
+.error-card::after {
+	position: absolute;
+	inset: auto -2rem -2rem auto;
+	width: 7rem;
+	height: 7rem;
+	content: "";
+	background: radial-gradient(
+		circle,
+		rgba(255, 102, 0, 0.28) 0,
+		transparent 68%
+	);
+}
+
+.error-card :where(.logo-banner--light, .logo-banner--dark) {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+.error-card :where(.logo-banner--dark) {
+	display: none;
+}
+
+html.oj-dark-mode .error-card :where(.logo-banner--light) {
+	display: none;
+}
+
+html.oj-dark-mode .error-card :where(.logo-banner--dark) {
+	display: block;
+}
+
+.error-card p {
+	position: relative;
+	z-index: 1;
+	margin: 1rem 0 0;
+	font-size: 0.98rem;
+	color: var(--text-light);
+	text-align: center;
+}
+
 .cta-group {
 	display: flex;
 	flex-wrap: wrap;
@@ -1117,6 +1236,10 @@ footer {
 
 	.tagline {
 		font-size: 1.25rem;
+	}
+
+	.error-page {
+		padding: 1.5rem;
 	}
 
 	.features {

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,11 +16,8 @@
 			property="og:description"
 			content="A browser extension for Hacker News with inline replies, unread tracking, keyboard shortcuts, following feeds, and other small UX fixes that add up. Follow on X, star on GitHub, or leave a review."
 		>
-		<meta property="og:url" content="https://orangejuiceextension.github.io/">
-		<meta
-			property="og:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta property="og:url" content="https://oj-hn.com/">
+		<meta property="og:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<meta property="og:image:type" content="image/png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
@@ -35,10 +32,7 @@
 			name="twitter:description"
 			content="A browser extension for Hacker News with inline replies, unread tracking, keyboard shortcuts, following feeds, and other small UX fixes that add up. Follow on X, star on GitHub, or leave a review."
 		>
-		<meta
-			name="twitter:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta name="twitter:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<meta
 			name="twitter:image:alt"
 			content="Orange Juice logo floating in a bright sky with fluffy clouds"
@@ -60,8 +54,8 @@
 				"applicationSubCategory": "Browser Extension",
 				"operatingSystem": "Chrome, Firefox",
 				"description": "Orange Juice is a browser extension for Hacker News with inline replies, unread tracking, keyboard shortcuts, following feeds, and other small UX fixes.",
-				"url": "https://orangejuiceextension.github.io/",
-				"image": "https://orangejuiceextension.github.io/assets/og-card-1200x630.png",
+				"url": "https://oj-hn.com/",
+				"image": "https://oj-hn.com/assets/og-card-1200x630.png",
 				"downloadUrl": "https://github.com/OrangeJuiceExtension/OrangeJuice/releases/latest",
 				"sameAs": [
 					"https://github.com/OrangeJuiceExtension/OrangeJuice",
@@ -147,7 +141,7 @@
 						Share on X
 					</a>
 					<a
-						href="mailto:?subject=Orange%20Juice%20-%20Make%20Hacker%20News%20Sweeter&body=Orange%20Juice%20is%20a%20browser%20extension%20for%20Hacker%20News%20with%20inline%20replies%2C%20unread%20tracking%2C%20following%2C%20and%20more.%0A%0Ahttps%3A%2F%2Forangejuiceextension.github.io%2F"
+						href="mailto:?subject=Orange%20Juice%20-%20Make%20Hacker%20News%20Sweeter&body=Orange%20Juice%20is%20a%20browser%20extension%20for%20Hacker%20News%20with%20inline%20replies%2C%20unread%20tracking%2C%20following%2C%20and%20more.%0A%0Ahttps%3A%2F%2Foj-hn.com%2F"
 						class="btn btn-share"
 					>
 						Share by Email

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
 		<link rel="canonical" href="https://oj-hn.com">
 		<link rel="icon" type="image/png" href="./assets/image-128.png">
 		<link rel="apple-touch-icon" href="./assets/image-128.png">
-		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-25">
+		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-27">
 		<link rel="sitemap" type="application/xml" href="./sitemap.xml">
 		<script src="./docs-theme.js?v=2026-02-09"></script>
 		<script type="application/ld+json">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -34,7 +34,7 @@
 		>
 		<meta name="twitter:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<title>Privacy Policy - Orange Juice</title>
-		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-24">
+		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-27">
 		<script src="./docs-theme.js?v=2026-02-09"></script>
 	</head>
 	<body class="oj-docs-page">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -8,7 +8,7 @@
 			name="description"
 			content="Privacy policy for Orange Juice, the Hacker News browser extension. No analytics, no tracking, no telemetry, and no third-party data collection."
 		>
-		<link rel="canonical" href="https://orangejuiceextension.github.io/privacy.html">
+		<link rel="canonical" href="https://oj-hn.com/privacy.html">
 		<meta property="og:locale" content="en_US">
 		<meta property="og:type" content="website">
 		<meta property="og:site_name" content="Orange Juice">
@@ -17,11 +17,8 @@
 			property="og:description"
 			content="Orange Juice runs locally in your browser and does not collect, store, transmit, or sell personal data."
 		>
-		<meta property="og:url" content="https://orangejuiceextension.github.io/privacy.html">
-		<meta
-			property="og:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta property="og:url" content="https://oj-hn.com/privacy.html">
+		<meta property="og:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<meta property="og:image:type" content="image/png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
@@ -35,10 +32,7 @@
 			name="twitter:description"
 			content="Orange Juice runs locally in your browser and does not collect, store, transmit, or sell personal data."
 		>
-		<meta
-			name="twitter:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta name="twitter:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<title>Privacy Policy - Orange Juice</title>
 		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-24">
 		<script src="./docs-theme.js?v=2026-02-09"></script>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -34,7 +34,7 @@
 		>
 		<meta name="twitter:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<title>Terms of Service - Orange Juice</title>
-		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-24">
+		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-27">
 		<script src="./docs-theme.js?v=2026-02-09"></script>
 	</head>
 	<body class="oj-docs-page">

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -8,7 +8,7 @@
 			name="description"
 			content="Terms of service for Orange Juice, the open-source Hacker News browser extension."
 		>
-		<link rel="canonical" href="https://orangejuiceextension.github.io/terms.html">
+		<link rel="canonical" href="https://oj-hn.com/terms.html">
 		<meta property="og:locale" content="en_US">
 		<meta property="og:type" content="website">
 		<meta property="og:site_name" content="Orange Juice">
@@ -17,11 +17,8 @@
 			property="og:description"
 			content="Simple terms for using Orange Juice, the open-source browser extension that improves the Hacker News experience."
 		>
-		<meta property="og:url" content="https://orangejuiceextension.github.io/terms.html">
-		<meta
-			property="og:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta property="og:url" content="https://oj-hn.com/terms.html">
+		<meta property="og:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<meta property="og:image:type" content="image/png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
@@ -35,10 +32,7 @@
 			name="twitter:description"
 			content="Simple terms for using Orange Juice, the open-source browser extension that improves the Hacker News experience."
 		>
-		<meta
-			name="twitter:image"
-			content="https://orangejuiceextension.github.io/assets/og-card-1200x630.png"
-		>
+		<meta name="twitter:image" content="https://oj-hn.com/assets/og-card-1200x630.png">
 		<title>Terms of Service - Orange Juice</title>
 		<link rel="stylesheet" href="./docs-theme.css?v=2026-04-24">
 		<script src="./docs-theme.js?v=2026-02-09"></script>


### PR DESCRIPTION
## Summary
- align docs canonical and social metadata with https://oj-hn.com
- add a custom GitHub Pages 404 page with homepage-style light/dark banner treatment
- bump docs stylesheet cache-busters after the theme update

## Testing
- bun run fix
- bun run check
- bun run compile
- bun run build
- bun run test